### PR TITLE
fix: Rails admin の細かなバグ修正まとめ (#36, #37 他)

### DIFF
--- a/backend/app/controllers/admin/cameras_controller.rb
+++ b/backend/app/controllers/admin/cameras_controller.rb
@@ -32,8 +32,11 @@ class Admin::CamerasController < Admin::Base
   end
 
   def destroy
-    @camera.destroy
-    redirect_to admin_cameras_path, notice: 'Camera was successfully destroyed.'
+    if @camera.destroy
+      redirect_to admin_cameras_path, notice: 'Camera was successfully destroyed.'
+    else
+      redirect_to admin_cameras_path, alert: 'Camera could not be destroyed.'
+    end
   end
 
   def lookup

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -6,38 +6,27 @@ class Admin::ImagesController < Admin::Base
     @images = Image.rank(:row_order).all
   end
 
-  def show
-    @image = Image.find(params[:id])
-  end
+  def show; end
 
   def new
     @image = Image.new
   end
 
-  def edit
-    @image = Image.find(params[:id])
-  end
+  def edit; end
 
   def create
-    @image = Image.new(image_params.except(:position))
+    @image = Image.new(image_params.except(:row_order_position))
+    @image.row_order_position = image_params[:row_order_position].to_i if image_params[:row_order_position].present?
 
     if @image.save
-      # positionパラメータがある場合は、指定位置に挿入
-      if image_params[:position].present?
-        position = image_params[:position].to_i
-        total_count = Image.count
-        insert_position = [position, total_count].min
-        @image.row_order_position = insert_position
-      end
       redirect_to admin_images_path(@image, format: nil), notice: 'Image was successfully created.'
     else
-      flash.now[:alert] = 'Image faild to create.'
+      flash.now[:alert] = 'Image failed to create.'
       render :new, status: :unprocessable_content
     end
   end
 
   def update
-    @image = Image.find(params[:id])
     params_hash = image_params.except(:row_order_position)
 
     if @image.update(params_hash)
@@ -56,7 +45,6 @@ class Admin::ImagesController < Admin::Base
   end
 
   def destroy
-    @image = Image.find(params[:id])
     if @image.destroy
       redirect_to admin_images_path, notice: 'Image was successfully destroyed.'
     else

--- a/backend/app/controllers/admin/lenses_controller.rb
+++ b/backend/app/controllers/admin/lenses_controller.rb
@@ -30,8 +30,11 @@ class Admin::LensesController < Admin::Base
   end
 
   def destroy
-    @lens.destroy
-    redirect_to admin_lenses_path, notice: 'Lens was successfully destroyed.'
+    if @lens.destroy
+      redirect_to admin_lenses_path, notice: 'Lens was successfully destroyed.'
+    else
+      redirect_to admin_lenses_path, alert: 'Lens could not be destroyed.'
+    end
   end
 
   def lookup

--- a/backend/app/javascript/controllers/exif_auto_reader_controller.js
+++ b/backend/app/javascript/controllers/exif_auto_reader_controller.js
@@ -11,8 +11,7 @@ export default class extends Controller {
   ]
 
   static LENS_TAGS = [
-    "LensModel", "Lens", "LensSpecification", "LensMake",
-    "LensSerialNumber", "LensFirmwareVersion", "LensSpec"
+    "LensModel", "Lens", "LensSpec"
   ]
 
   connect() {
@@ -49,7 +48,7 @@ export default class extends Controller {
         }
 
         const lensName = this.extractLensName(file)
-        if (lensName && lensName !== "undefined" && this.hasLensSelectTarget) {
+        if (lensName && this.hasLensSelectTarget) {
           if (await this.lookupLens(lensName)) updatedFields++
         }
 
@@ -73,11 +72,12 @@ export default class extends Controller {
   extractLensName(file) {
     for (const tag of this.constructor.LENS_TAGS) {
       const value = window.EXIF.getTag(file, tag)
-      if (value && value !== "undefined") return value
+      if (value && typeof value === 'string' && value !== "undefined") return value
     }
 
+    // exif-jsが未知のタグを"undefined"キーで格納することがある
     const allTags = window.EXIF.getAllTags(file)
-    if (allTags?.undefined && typeof allTags.undefined === 'string') {
+    if (allTags?.undefined && typeof allTags.undefined === 'string' && allTags.undefined !== "undefined") {
       return allTags.undefined
     }
     return null

--- a/backend/app/models/camera_name.rb
+++ b/backend/app/models/camera_name.rb
@@ -23,7 +23,7 @@ class CameraName
     @load_camera_names ||= begin
       yaml_path = Rails.root.join("config/camera_names.yml")
       if File.exist?(yaml_path)
-        YAML.load_file(yaml_path) || {}
+        YAML.safe_load_file(yaml_path, permitted_classes: [Symbol]) || {}
       else
         {}
       end

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -43,7 +43,7 @@ class Image < ApplicationRecord
     published
       .filter_by_categories(category_ids)
       .with_attached_file
-      .includes(:camera, :lens)
+      .includes(:camera, :lens, :categories)
       .ordered_for_gallery
   end
 

--- a/backend/app/views/admin/images/show.html.haml
+++ b/backend/app/views/admin/images/show.html.haml
@@ -15,10 +15,10 @@
   .col-md-9= @image.taken_at
 .row.py-1
   .col-md-3.fw-bold Camera
-  .col-md-9= @image.camera_id
+  .col-md-9= @image.camera&.name
 .row.py-1
   .col-md-3.fw-bold Lens
-  .col-md-9= @image.lens_id
+  .col-md-9= @image.lens&.name
 .row.py-1
   .col-md-3.fw-bold Is published
   .col-md-9= @image.is_published


### PR DESCRIPTION
## Summary
- **#36**: EXIF レンズ名が undefined になる問題を修正（不適切なタグ除外、型チェック追加）
- **#37**: 画像作成時に display_order (row_order_position) が反映されない問題を修正
- Camera/Lens の destroy で `restrict_with_error` 失敗時にも成功メッセージが出る問題を修正
- Image show 画面で camera_id/lens_id が数値IDのまま表示される問題を修正
- `for_gallery` クエリに `:categories` の includes 追加（N+1 解消）
- `YAML.load_file` → `YAML.safe_load_file` に変更
- images_controller の冗長な `Image.find` 除去、タイポ修正、DB 二重書き込み解消

## Test plan
- [x] `bundle exec rspec` 全77テストパス
- [ ] admin 画面で画像作成時に row_order_position が反映されることを確認
- [ ] EXIF 読み取りでレンズ名が正しく取得されることを確認
- [ ] Camera/Lens を関連画像がある状態で削除し、エラーメッセージが表示されることを確認

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)