### PR TITLE
ci: Rubocop 差分実行 + E2E ワークフロー改善

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -26,7 +28,21 @@ jobs:
           bundler-cache: true
           working-directory: backend
 
-      - name: Run rubocop
+      - name: Get changed Ruby files
+        id: changed
+        if: github.event_name == 'pull_request'
+        run: |
+          FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD -- 'backend/**/*.rb' | sed 's|^backend/||' | tr '\n' ' ')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "any=$([ -n "$FILES" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Run rubocop (changed files only)
+        if: github.event_name == 'pull_request' && steps.changed.outputs.any == 'true'
+        working-directory: ./backend
+        run: bundle exec rubocop --force-exclusion ${{ steps.changed.outputs.files }}
+
+      - name: Run rubocop (full)
+        if: github.event_name == 'push'
         working-directory: ./backend
         run: bundle exec rubocop
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,9 +65,24 @@ jobs:
 
       - name: Install e2e dependencies
         working-directory: ./e2e
-        run: |
-          npm install
-          npx playwright install --with-deps chromium
+        run: npm install
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('e2e/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ./e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+        working-directory: ./e2e
 
       - name: Run e2e tests
         working-directory: ./e2e

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? 'github' : 'html',
+  reporter: process.env.CI ? [['github'], ['html']] : 'html',
   use: {
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
## 概要
- **#61**: PR 時の Rubocop を変更 `.rb` ファイルのみに絞り、CI 時間を短縮。main push 時はフル実行を維持
- **#80**: E2E ワークフローに Playwright ブラウザキャッシュ追加、reporter を github + html 両方に変更し HTML レポートが artifact に保存されるように

## 実装方針
- `git diff --name-only` で変更ファイルを取得し、`.rb` ファイルがある場合のみ rubocop 実行
- `actions/cache` で `~/.cache/ms-playwright` をキャッシュし、ヒット時は system deps のみインストール

## テスト方針
- マージ後に backend CI / E2E ワークフローが正常に動作するか確認
- Rubocop 差分実行は次回 backend 変更の PR で検証可能

Closes #61
Closes #80

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)