### PR TITLE
fix: コード品質改善（未使用コード削除・二重保存修正・型整合・エラー表示）

### DIFF
--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -28,14 +28,10 @@ class Admin::ImagesController < Admin::Base
 
   def update
     params_hash = image_params.except(:row_order_position)
+    @image.assign_attributes(params_hash)
+    @image.row_order_position = image_params[:row_order_position].to_i if image_params[:row_order_position].present?
 
-    if @image.update(params_hash)
-      # row_order_positionが指定されている場合は順序を更新
-      if image_params[:row_order_position].present?
-        position = image_params[:row_order_position].to_i
-        @image.row_order_position = position
-        @image.save
-      end
+    if @image.save
       redirect_to admin_images_path(@image, format: nil), notice: 'Image was successfully updated.'
     else
       flash[:alert] = 'Image failed to update.'

--- a/backend/app/controllers/api/images_controller.rb
+++ b/backend/app/controllers/api/images_controller.rb
@@ -1,6 +1,4 @@
 class Api::ImagesController < ApplicationController
-  include Rails.application.routes.url_helpers
-
   def index
     limit = [(params[:limit] || 20).to_i, 50].min
     images = Image.for_gallery(
@@ -23,7 +21,7 @@ class Api::ImagesController < ApplicationController
   def category_ids_param
     case params[:categories]
     when String
-      params[:categories].split(',').map(&:strip)
+      params[:categories].split(',').map { |id| id.strip.to_i }
     else
       params[:categories]
     end

--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -93,6 +93,8 @@ export default function GalleryApp({
         setImages((prev) => [...prev, ...result.images]);
         setNextCursor(result.nextCursor);
         setHasMore(result.hasMore);
+      } else {
+        setFetchError(true);
       }
     } finally {
       setIsLoadingMore(false);


### PR DESCRIPTION
## 概要

定期コード品質チェックで発見した問題を修正します。

## 変更内容

### バックエンド (Ruby/Rails)

#### 1. 未使用の `include` を削除（`Api::ImagesController`）
`include Rails.application.routes.url_helpers` が含まれていたが、このコントローラー内では URL ヘルパーを直接使用していなかった（URL 生成はモデルの `CdnAttachedFile` コンサーンが担当）。不要な include を削除。

#### 2. 画像更新時の二重保存を修正（`Admin::ImagesController#update`）
`row_order_position` が指定された場合に `@image.update(params_hash)` → `@image.save` と2回 DB 書き込みが発生していた。`assign_attributes` + 単一の `save` に統合し、無駄な DB ラウンドトリップを削減。

#### 3. カテゴリ ID の型を整数に修正（`Api::ImagesController#category_ids_param`）
URL クエリパラメータ `?categories=1,2,3` を分割した際、文字列のまま渡していた。ActiveRecord の暗黙キャストで動作はしていたが、型の不整合を修正し `.to_i` で整数変換するよう修正。

### フロントエンド (TypeScript/React)

#### 4. 追加読み込み失敗時のエラー表示を修正（`GalleryApp`）
無限スクロールで次ページを読み込む `loadMore` が失敗した場合に、`fetchError` が更新されずユーザーへのフィードバックが一切なかった。`result.error` が `true` の場合に `setFetchError(true)` を呼ぶよう修正。

## チェックで特定したが今回修正しない項目（技術的負債）

| 項目 | 内容 | 優先度 |
|------|------|--------|
| 孤立テーブル | `articles`・`publishments` テーブルが DB に存在するが対応するモデルがない | 低 |
| 型安全性 | `apiFetch` のエラー時戻り値が `[] as unknown as T`（型キャストで回避中） | 低 |
| `useImages.ts` の複雑性 | カテゴリ ID を文字列にシリアライズして依存配列に渡し、再パースしている | 低 |
| `ImageModal` のセマンティクス | `<div role="dialog">` を使用、ネイティブ `<dialog>` 要素に置き換えが望ましい | 低 |