### PR TITLE
fix: loadMore成功時にエラー状態がリセットされないバグを修正

### DIFF
--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -93,6 +93,7 @@ export default function GalleryApp({
         setImages((prev) => [...prev, ...result.images]);
         setNextCursor(result.nextCursor);
         setHasMore(result.hasMore);
+        setFetchError(false);
       } else {
         setFetchError(true);
       }


### PR DESCRIPTION
## 概要

ギャラリーページの「続きを読む」（loadMore）処理において、成功時にエラー状態がリセットされないバグを修正します。

## 問題

`GalleryApp.tsx` の `loadMore` 関数は、失敗時には `setFetchError(true)` を呼び出しますが、成功時には `setFetchError(false)` を呼び出していませんでした。

これにより、以下のシナリオでエラーバナーが残り続けます：

1. ユーザーがカテゴリ切り替え時にAPIエラーが発生 → エラーバナー表示
2. その後、スクロールで `loadMore` が成功 → **エラーバナーが消えずに残り続ける** ← バグ

または：

1. `loadMore` が失敗 → エラーバナー表示
2. ユーザーが再度スクロール → `loadMore` が成功 → **エラーバナーが消えずに残り続ける** ← バグ

## 修正内容

`loadMore` の成功ブランチに `setFetchError(false)` を追加。

```tsx
if (!result.error) {
  setImages((prev) => [...prev, ...result.images]);
  setNextCursor(result.nextCursor);
  setHasMore(result.hasMore);
  setFetchError(false); // 追加
} else {
  setFetchError(true);
}
```

## 関連

前回のPR #99 で `loadMore` 失敗時の `setFetchError(true)` が追加されましたが、成功時のリセット処理が漏れていました。

https://claude.ai/code/session_012nMYeKWM6zn4C9XuVk2Hhf