### PR TITLE
fix: 初期データフェッチ失敗時のエラー状態を適切に処理する

### DIFF
--- a/frontend/src/app/_components/ProjectsSection.tsx
+++ b/frontend/src/app/_components/ProjectsSection.tsx
@@ -3,7 +3,7 @@ import ProjectCard from '../projects/_components/ProjectCard';
 import { fetchProjects } from '@/hooks/projectApi';
 
 export default async function ProjectsSection() {
-  const { projects } = await fetchProjects({ fetchInit: { next: { revalidate: 300 } } });
+  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: 300 } } });
   return (
     <section className="bg-background px-6 py-20 md:py-24 snap-ignore" aria-labelledby="projects-heading">
       <div className="mx-auto w-full max-w-5xl">
@@ -20,7 +20,9 @@ export default async function ProjectsSection() {
           </Link>
         </div>
 
-        {projects.length > 0 ? (
+        {error ? (
+          <p className="mt-10 text-sm text-red-600">読み込みに失敗しました。</p>
+        ) : projects.length > 0 ? (
           <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
             {projects.map((project) => (
               <ProjectCard key={project.id} project={project} />

--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -12,6 +12,7 @@ type GalleryAppProps = {
   initialImages?: ImageType[];
   initialNextCursor?: string | null;
   initialHasMore?: boolean;
+  initialFetchError?: boolean;
 };
 
 export default function GalleryApp({
@@ -19,12 +20,13 @@ export default function GalleryApp({
   initialImages = [],
   initialNextCursor = null,
   initialHasMore = false,
+  initialFetchError = false,
 }: GalleryAppProps) {
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
   const [images, setImages] = useState<ImageType[]>(initialImages);
   const [isLoadingImages, setIsLoadingImages] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [fetchError, setFetchError] = useState(false);
+  const [fetchError, setFetchError] = useState(initialFetchError);
   const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
   const [hasMore, setHasMore] = useState(initialHasMore);
   const initialLoadRef = useRef(true);

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -27,6 +27,7 @@ export default async function Page() {
           initialImages={initialImages}
           initialNextCursor={imagesResult.nextCursor}
           initialHasMore={imagesResult.hasMore}
+          initialFetchError={imagesResult.error || categoriesResult.error}
         />
       </div>
     </>


### PR DESCRIPTION
- ProjectsSection: fetchProjectsのエラー状態を無視していたため、API失敗時に 「まだありません」と誤表示されていた問題を修正。エラー時は赤字メッセージを表示
- GalleryApp: initialFetchErrorプロップを追加し、SSR時のAPI失敗を初期エラー 状態として反映できるよう対応
- gallery/page.tsx: imagesResult.error / categoriesResult.errorをGalleryAppに 渡すよう修正し、初回ロード失敗時もエラーメッセージが表示されるようにした

https://claude.ai/code/session_01VQJVF8Yv2yFugCkahMQbf4