### PR TITLE
fix: CORSの過剰なHTTPメソッド許可とフロントエンドの型安全性を修正

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -3,7 +3,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins ENV['FRONTEND_ORIGIN'] || "http://localhost:3002"
     resource "*",
              headers: :any,
-             methods: %i[get post put patch delete options head],
+             methods: %i[get post options head],
              expose: %w[access-token expiry token-type uid client]
   end
 end

--- a/frontend/src/hooks/categoryApi.ts
+++ b/frontend/src/hooks/categoryApi.ts
@@ -14,5 +14,5 @@ export async function fetchCategories({
   fetchInit,
 }: FetchCategoriesOptions = {}): Promise<FetchCategoriesResult> {
   const { data, error } = await apiFetch<CategoryType[]>('/categories', 'categories', fetchInit);
-  return { categories: data, error };
+  return { categories: error ? [] : data, error };
 }

--- a/frontend/src/hooks/projectApi.ts
+++ b/frontend/src/hooks/projectApi.ts
@@ -14,5 +14,5 @@ export async function fetchProjects({
   fetchInit,
 }: FetchProjectsOptions = {}): Promise<FetchProjectsResult> {
   const { data, error } = await apiFetch<ProjectType[]>('/projects', 'projects', fetchInit);
-  return { projects: data, error };
+  return { projects: error ? [] : data, error };
 }

--- a/frontend/src/utils/api.test.ts
+++ b/frontend/src/utils/api.test.ts
@@ -41,20 +41,20 @@ describe('apiFetch', () => {
     expect(fetch).toHaveBeenCalledWith('https://api.test/items', undefined);
   });
 
-  it('returns empty array and error on non-ok response', async () => {
+  it('returns null and error on non-ok response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       statusText: 'Not Found',
     }));
 
     const result = await apiFetch('/items', 'items');
-    expect(result).toEqual({ data: [], error: true });
+    expect(result).toEqual({ data: null, error: true });
   });
 
-  it('returns empty array and error on network failure', async () => {
+  it('returns null and error on network failure', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
 
     const result = await apiFetch('/items', 'items');
-    expect(result).toEqual({ data: [], error: true });
+    expect(result).toEqual({ data: null, error: true });
   });
 });

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -28,11 +28,11 @@ export async function apiFetch<T>(
     const response = await fetch(url, init);
     if (!response.ok) {
       console.error(`Failed to fetch ${label}:`, response.statusText);
-      return { data: [] as unknown as T, error: true };
+      return { data: null as unknown as T, error: true };
     }
     return { data: (await response.json()) as T, error: false };
   } catch (error) {
     console.error(`Failed to fetch ${label}:`, error);
-    return { data: [] as unknown as T, error: true };
+    return { data: null as unknown as T, error: true };
   }
 }


### PR DESCRIPTION
- CORS設定からput/patch/deleteを削除（公開APIにはget/post/options/headで十分）
- apiFetch()のエラー時フォールバックを`[] as unknown as T`から`null as unknown as T`に変更
- categoryApi/projectApiでエラー時に明示的に空配列を返すよう修正し、unsafe castへの依存を解消

https://claude.ai/code/session_01Fv1vunQBjMVJFesBGPkkg7