### PR TITLE
fix: CORSの過剰なヘッダー許可と未使用exposeヘッダーを修正

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -2,8 +2,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins ENV['FRONTEND_ORIGIN'] || "http://localhost:3002"
     resource "*",
-             headers: :any,
-             methods: %i[get post options head],
-             expose: %w[access-token expiry token-type uid client]
+             headers: %w[Content-Type Accept Authorization],
+             methods: %i[get post options head]
   end
 end


### PR DESCRIPTION
## 概要

コード品質チェック（2026-04-13）で発見したCORS設定のセキュリティ問題を修正します。

## 変更内容

### `backend/config/initializers/cors.rb`

**問題1: `headers: :any` — 任意のリクエストヘッダーを許可**

任意のリクエストヘッダーを受け入れる設定になっており、不要なヘッダーも含めてブラウザからのCORSリクエストで使用可能な状態でした。

```ruby
# Before
headers: :any,

# After
headers: %w[Content-Type Accept Authorization],
```

**問題2: 未使用の `expose` ヘッダー**

`expose` に Devise Token Auth 用のヘッダー（`access-token`, `expiry`, `token-type`, `uid`, `client`）が設定されていましたが、このアプリは標準セッション認証（Devise）を使用しており、Devise Token Auth は導入されていません。これらのヘッダーはレスポンスに含まれることはなく、設定が意味をなしていませんでした。

```ruby
# Before (削除)
expose: %w[access-token expiry token-type uid client]
```

## その他のチェック結果（今回は対応なし）

| 問題 | 場所 | 理由 |
|------|------|------|
| Content Security Policy が無効 | `config/initializers/content_security_policy.rb` | Admin UI への影響リスクがあり、慎重な実装が必要 |
| 孤立DBテーブル（`articles`, `publishments`）| `db/schema.rb` | マイグレーション実行が必要。別途対応 |
| `Camera.lookup` のLIKEパターンのエスケープ | `app/models/camera.rb` | Admin専用エンドポイントで認証済みユーザーのみアクセス可能のため影響小 |

## テスト計画

- [ ] バックエンド起動後、フロントエンドからギャラリー・カテゴリ・プロジェクト一覧を正常に取得できることを確認
- [ ] Admin UIが正常に動作することを確認
- [ ] CORSプリフライトリクエストが正常に通ることを確認