### PR TITLE
fix: フォント未適用・不正なTailwindクラス・未使用型フィールドを修正

### DIFF
--- a/frontend/src/app/gallery/_components/CategoryCheckbox.test.tsx
+++ b/frontend/src/app/gallery/_components/CategoryCheckbox.test.tsx
@@ -7,8 +7,6 @@ import { CategoryType } from '@/utils/types';
 const category: CategoryType = {
   id: 1,
   name: 'Landscape',
-  created_at: '2025-01-01',
-  updated_at: '2025-01-01',
 };
 
 describe('CategoryCheckbox', () => {

--- a/frontend/src/app/gallery/_components/ImageFilter.test.tsx
+++ b/frontend/src/app/gallery/_components/ImageFilter.test.tsx
@@ -5,9 +5,9 @@ import ImageFilter from './ImageFilter';
 import { CategoryType } from '@/utils/types';
 
 const categories: CategoryType[] = [
-  { id: 1, name: 'Landscape', created_at: '', updated_at: '' },
-  { id: 2, name: 'Portrait', created_at: '', updated_at: '' },
-  { id: 3, name: 'Street', created_at: '', updated_at: '' },
+  { id: 1, name: 'Landscape' },
+  { id: 2, name: 'Portrait' },
+  { id: 3, name: 'Street' },
 ];
 
 describe('ImageFilter', () => {

--- a/frontend/src/app/gallery/_components/ImageModal.tsx
+++ b/frontend/src/app/gallery/_components/ImageModal.tsx
@@ -221,7 +221,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
         </div>
 
         {/* Meta info */}
-        <div className="px-4 pb-4 space-y-1 shrink-0 wrap-break-word">
+        <div className="px-4 pb-4 space-y-1 shrink-0 break-words">
           <h3 id={titleId} className="text-lg font-semibold">
             {image.title}
           </h3>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -46,7 +46,7 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), Arial, sans-serif;
 }
 
 .snap-ignore {

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -7,8 +7,6 @@ export type ImageType = {
   lens_name: string;
   row_order: number;
   is_published: boolean;
-  created_at: string;
-  updated_at: string;
   file: string; // 画像のURL
   thumbnail?: string | null;
   width: number | null;
@@ -24,8 +22,6 @@ export type PaginatedImages = {
 export type CategoryType = {
   id: number;
   name: string;
-  created_at: string;
-  updated_at: string;
 };
 
 export type ProjectType = {


### PR DESCRIPTION
## 概要

コード品質チェック（2026-04-15）で発見した以下の問題を修正します。

---

## 修正内容

### 1. フォントが実際に適用されていなかった（バグ）

**ファイル:** `frontend/src/app/globals.css`

`layout.tsx` で Next.js `localFont` の `variable` オプションを使って `--font-geist-sans` CSS 変数を設定しているにもかかわらず、`globals.css` の `body` では `font-family: Arial, Helvetica, sans-serif` がハードコードされていました。

そのため、Geist フォントが一切適用されていませんでした。

**修正:** `font-family: var(--font-geist-sans), Arial, sans-serif;` に変更。

---

### 2. 無効な Tailwind CSS クラス（バグ）

**ファイル:** `frontend/src/app/gallery/_components/ImageModal.tsx`

モーダルのメタ情報エリアに `wrap-break-word` というクラスが使われていましたが、これは Tailwind CSS に存在しないクラスです（`overflow-wrap: break-word` を適用する正しいクラスは `break-words`）。

その結果、画像タイトルや長いテキストが折り返されず、レイアウト崩れの可能性がありました。

**修正:** `wrap-break-word` → `break-words` に変更。

---

### 3. 未使用の型フィールドを削除（コード品質）

**ファイル:** `frontend/src/utils/types.ts`、関連テストファイル

`ImageType` および `CategoryType` に `created_at` / `updated_at` フィールドが定義されていましたが、フロントエンドのどのコンポーネントでも参照されていませんでした。API レスポンスに含まれる値ですが、型定義には使用するフィールドのみを含めるべきです。

**修正:** 両型から `created_at` / `updated_at` を削除し、テストのモックオブジェクトも合わせて更新。

---

## チェックリスト

- [x] `globals.css`: Geist フォント変数を参照するように修正
- [x] `ImageModal.tsx`: `break-words` クラスに修正
- [x] `types.ts`: `ImageType` / `CategoryType` の未使用フィールド削除
- [x] `CategoryCheckbox.test.tsx` / `ImageFilter.test.tsx`: モック更新