### PR TITLE
fix: イベントリスナーリーク・LIKEインジェクション・null参照を修正

### DIFF
--- a/backend/app/controllers/admin/lenses_controller.rb
+++ b/backend/app/controllers/admin/lenses_controller.rb
@@ -45,12 +45,12 @@ class Admin::LensesController < Admin::Base
       lens = Lens.where("LOWER(name) = ?", name.downcase).first
 
       # 2. 部分一致（大文字小文字無視）
-      lens ||= Lens.where("LOWER(name) LIKE ?", "%#{name.downcase}%").first
+      lens ||= Lens.where("LOWER(name) LIKE ?", "%#{Lens.sanitize_sql_like(name.downcase)}%").first
 
       # 3. 空白を正規化して部分一致
       unless lens
         cleaned_name = name.gsub(/\s+/, ' ').strip
-        lens = Lens.where("LOWER(REPLACE(name, '  ', ' ')) LIKE ?", "%#{cleaned_name.downcase}%").first
+        lens = Lens.where("LOWER(REPLACE(name, '  ', ' ')) LIKE ?", "%#{Lens.sanitize_sql_like(cleaned_name.downcase)}%").first
       end
 
       if lens

--- a/backend/app/controllers/admin/lenses_controller.rb
+++ b/backend/app/controllers/admin/lenses_controller.rb
@@ -50,7 +50,8 @@ class Admin::LensesController < Admin::Base
       # 3. 空白を正規化して部分一致
       unless lens
         cleaned_name = name.gsub(/\s+/, ' ').strip
-        lens = Lens.where("LOWER(REPLACE(name, '  ', ' ')) LIKE ?", "%#{Lens.sanitize_sql_like(cleaned_name.downcase)}%").first
+        sanitized = Lens.sanitize_sql_like(cleaned_name.downcase)
+        lens = Lens.where("LOWER(REPLACE(name, '  ', ' ')) LIKE ?", "%#{sanitized}%").first
       end
 
       if lens

--- a/backend/app/javascript/controllers/direct_upload_controller.js
+++ b/backend/app/javascript/controllers/direct_upload_controller.js
@@ -6,17 +6,22 @@ export default class extends Controller {
   static targets = ["input", "progress", "error"]
 
   connect() {
-    this.element.addEventListener("direct-upload:initialize", this.initialize.bind(this))
-    this.element.addEventListener("direct-upload:progress", this.progress.bind(this))
-    this.element.addEventListener("direct-upload:error", this.error.bind(this))
-    this.element.addEventListener("direct-upload:end", this.end.bind(this))
+    this._boundInitialize = this.initialize.bind(this)
+    this._boundProgress = this.progress.bind(this)
+    this._boundError = this.error.bind(this)
+    this._boundEnd = this.end.bind(this)
+
+    this.element.addEventListener("direct-upload:initialize", this._boundInitialize)
+    this.element.addEventListener("direct-upload:progress", this._boundProgress)
+    this.element.addEventListener("direct-upload:error", this._boundError)
+    this.element.addEventListener("direct-upload:end", this._boundEnd)
   }
 
   disconnect() {
-    this.element.removeEventListener("direct-upload:initialize", this.initialize)
-    this.element.removeEventListener("direct-upload:progress", this.progress)
-    this.element.removeEventListener("direct-upload:error", this.error)
-    this.element.removeEventListener("direct-upload:end", this.end)
+    this.element.removeEventListener("direct-upload:initialize", this._boundInitialize)
+    this.element.removeEventListener("direct-upload:progress", this._boundProgress)
+    this.element.removeEventListener("direct-upload:error", this._boundError)
+    this.element.removeEventListener("direct-upload:end", this._boundEnd)
   }
 
   initialize(event) {

--- a/backend/app/javascript/controllers/sortable_controller.js
+++ b/backend/app/javascript/controllers/sortable_controller.js
@@ -47,7 +47,10 @@ export default class extends Controller {
     const flashDiv = document.createElement('div')
     flashDiv.className = 'alert alert-danger'
     flashDiv.textContent = '並び替えに失敗しました'
-    document.querySelector('.container').insertBefore(flashDiv, document.querySelector('.table-responsive'))
+    const container = document.querySelector('.container')
+    if (container) {
+      container.insertBefore(flashDiv, document.querySelector('.table-responsive'))
+    }
   }
 
   async #updatePosition(itemId, position) {

--- a/backend/app/models/camera.rb
+++ b/backend/app/models/camera.rb
@@ -10,20 +10,20 @@ class Camera < ApplicationRecord
     # カメラ名とメーカー名の両方が提供されている場合
     if camera_name.present? && manufacturer.present?
       camera = where("LOWER(name) LIKE ? AND LOWER(manufacturer) LIKE ?",
-                     "%#{camera_name.downcase}%",
-                     "%#{manufacturer.downcase}%").first
+                     "%#{sanitize_sql_like(camera_name.downcase)}%",
+                     "%#{sanitize_sql_like(manufacturer.downcase)}%").first
       return camera if camera
     end
 
     # カメラ名のみで検索
     if camera_name.present?
-      camera = where("LOWER(name) LIKE ?", "%#{camera_name.downcase}%").first
+      camera = where("LOWER(name) LIKE ?", "%#{sanitize_sql_like(camera_name.downcase)}%").first
       return camera if camera
     end
 
     # メーカー名のみで検索
     if manufacturer.present?
-      camera = where("LOWER(manufacturer) LIKE ?", "%#{manufacturer.downcase}%").first
+      camera = where("LOWER(manufacturer) LIKE ?", "%#{sanitize_sql_like(manufacturer.downcase)}%").first
       return camera if camera
     end
 


### PR DESCRIPTION
## Summary
- `Lens` / `Camera` モデルの LIKE クエリで `sanitize_sql_like` を使い、%や_によるワイルドカードインジェクションを防ぐ
- `direct_upload_controller` のイベントリスナー解除が `bind` の参照不一致で機能していなかった問題を修正（bound 関数を保持）
- `sortable_controller` で `.container` が見つからない場合の null 参照を防ぐ

## Test plan
- [ ] 管理画面で lens / camera のサジェスト検索が従来通り動く
- [ ] ファイルのダイレクトアップロード時、進捗・エラー・完了イベントが正しく処理される
- [ ] 並び替え失敗時にエラーフラッシュが表示され、該当コンテナが無い場合もエラーにならない

🤖 Generated with [Claude Code](https://claude.com/claude-code)