### PR TITLE
fix: ドラッグ失敗時にDOMを元の順序へ正しく巻き戻す

### DIFF
--- a/backend/app/javascript/controllers/sortable_controller.js
+++ b/backend/app/javascript/controllers/sortable_controller.js
@@ -7,10 +7,12 @@ export default class extends Controller {
   static targets = ['list']
 
   connect() {
+    this._orderBeforeDrag = []
     this.sortable = window.Sortable.create(this.listTarget, {
       animation: 150,
       handle: '.handle',
       ghostClass: 'sortable-ghost',
+      onStart: () => { this._orderBeforeDrag = this.sortable.toArray() },
       onEnd: this.onSortEnd.bind(this)
     })
   }
@@ -25,6 +27,7 @@ export default class extends Controller {
   async onSortEnd(evt) {
     const { item, newIndex } = evt
     const itemId = item.dataset.imageId
+    const savedOrder = this._orderBeforeDrag
 
     try {
       await this.#updatePosition(itemId, newIndex)
@@ -32,7 +35,7 @@ export default class extends Controller {
       this.#updateOrderNumbers()
     } catch {
       // エラー時は DOM を元に戻す
-      this.sortable.sort(this.sortable.toArray(), true)
+      this.sortable.sort(savedOrder, true)
       this.#showError()
     }
   }


### PR DESCRIPTION
## 概要

コード品質チェック（2026-05-01）で発見したバグを修正します。

### 問題

`sortable_controller.js` の `onSortEnd` で、API呼び出しが失敗した際のDOM巻き戻し処理が機能していませんでした。

```js
// 修正前: ドラッグ後の現在順序を sort() に渡しているため巻き戻しは無効
this.sortable.sort(this.sortable.toArray(), true)
```

`toArray()` はドラッグ完了後の**現在のDOM順序**を返すため、その値で `sort()` を呼んでも何も変化しません。ユーザーがドラッグ操作を行い API が失敗した場合、画面上の順序がDBと不一致のまま残ってしまいます。

### 修正内容

`onStart` コールバックでドラッグ開始直前の順序を保存し、エラー時にその保存値で `sort()` を呼ぶようにしました。

```js
// onStart で開始前の順序を保存
onStart: () => { this._orderBeforeDrag = this.sortable.toArray() }

// onSortEnd のエラー時に保存した順序で巻き戻し
const savedOrder = this._orderBeforeDrag
// ...
this.sortable.sort(savedOrder, true)
```

## 影響範囲

- `backend/app/javascript/controllers/sortable_controller.js` のみ
- 管理画面の画像並び替え機能

## テスト方法

1. 管理画面の画像一覧を開く
2. 画像をドラッグ＆ドロップで並び替える
3. APIが失敗するようにネットワークを切断した状態で並び替えを試みる
4. 修正後: DOMが元の順序に戻り、エラーメッセージが表示されることを確認

https://claude.ai/code/session_01L9F6LUHTBseNbu31RjTKai

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9F6LUHTBseNbu31RjTKai)_