### PR TITLE
fix(ci): hardcode test postgres credentials for Dependabot

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -51,16 +51,14 @@ jobs:
     needs: rubocop
     env:
       PGHOST: 127.0.0.1
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_USER: postgres
       POSTGRES_DB: portfolio_test
       CLOUDFRONT_BASE_URL: ${{ secrets.CLOUDFRONT_BASE_URL }}
     services:
       postgres:
         image: postgres:16
         env:
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: portfolio_test
         ports:
           - 5432:5432


### PR DESCRIPTION
## Summary
- Dependabot PRs can't access repository secrets, causing the postgres service container to fail with "POSTGRES_PASSWORD not specified"
- Test DB creds for an ephemeral CI container don't need to be secret — hardcode to postgres/postgres

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, rebase Dependabot PRs (#131, #130, #121) and confirm rspec runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)