### PR TITLE
fix(ci): CLOUDFRONT_BASE_URL fallback for Dependabot

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -53,7 +53,7 @@ jobs:
       PGHOST: 127.0.0.1
       POSTGRES_USER: postgres
       POSTGRES_DB: portfolio_test
-      CLOUDFRONT_BASE_URL: ${{ secrets.CLOUDFRONT_BASE_URL }}
+      CLOUDFRONT_BASE_URL: ${{ secrets.CLOUDFRONT_BASE_URL || 'https://cdn.example.test' }}
     services:
       postgres:
         image: postgres:16


### PR DESCRIPTION
## Summary
- Dependabot rspec runs failed because \`secrets.CLOUDFRONT_BASE_URL\` is empty for Dependabot, which made the cdn initializer set \`cdn_base_url = nil\`, breaking Project#file_url spec
- Add a test-only fallback so CI runs whether or not secrets are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)