### PR TITLE
fix: コード品質改善 - セキュリティ・型安全性・重複排除

### DIFF
--- a/backend/app/controllers/api/images_controller.rb
+++ b/backend/app/controllers/api/images_controller.rb
@@ -29,9 +29,7 @@ class Api::ImagesController < ApplicationController
 
   # カメラのidとレンズのidを名前に変更して渡す
   def image_json(image)
-    metadata = image.file.attached? ? image.file.metadata : {}
-    width = metadata['width']&.to_i
-    height = metadata['height']&.to_i
+    width, height = file_dimensions(image.file)
 
     image.as_json(except: %i[camera_id lens_id]).merge(
       file: image.file_url,

--- a/backend/app/controllers/api/projects_controller.rb
+++ b/backend/app/controllers/api/projects_controller.rb
@@ -7,9 +7,7 @@ class Api::ProjectsController < ApplicationController
   private
 
   def project_json(project)
-    metadata = project.file.attached? ? project.file.metadata : {}
-    width = metadata['width']&.to_i
-    height = metadata['height']&.to_i
+    width, height = file_dimensions(project.file)
 
     project.as_json(only: %i[id title link]).merge(
       file: project.file_url,

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::Base
+  private
+
+  def file_dimensions(attachment)
+    metadata = attachment.attached? ? attachment.metadata : {}
+    [metadata['width']&.to_i, metadata['height']&.to_i]
+  end
 end

--- a/backend/config/initializers/content_security_policy.rb
+++ b/backend/config/initializers/content_security_policy.rb
@@ -19,6 +19,6 @@ Rails.application.configure do
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
-  # Report-only mode: log violations without blocking, to verify policy before enforcement.
-  config.content_security_policy_report_only = true
+  # Enforce in production; report-only in other environments to verify policy changes safely.
+  config.content_security_policy_report_only = !Rails.env.production?
 end

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -4,10 +4,13 @@ import path from 'path';
 const authFile = path.join(__dirname, '..', '.auth', 'admin.json');
 
 setup('authenticate as admin', async ({ page }) => {
+  const email = process.env.E2E_ADMIN_EMAIL ?? 'admin@example.com';
+  const password = process.env.E2E_ADMIN_PASSWORD ?? 'password123';
+
   await page.goto('/users/sign_in');
 
-  await page.getByRole('textbox', { name: 'Email' }).fill('admin@example.com');
-  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('textbox', { name: 'Email' }).fill(email);
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
   await page.getByRole('button', { name: 'Log in' }).click();
 
   // Wait for redirect after login

--- a/frontend/src/app/gallery/_components/ImageModal.tsx
+++ b/frontend/src/app/gallery/_components/ImageModal.tsx
@@ -126,14 +126,8 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
 
   const captionId = image.caption ? descriptionId : undefined;
 
-  const hasDimensions =
-    typeof image.width === 'number' &&
-    image.width > 0 &&
-    typeof image.height === 'number' &&
-    image.height > 0;
-
-  const displayWidth = hasDimensions ? image.width! : 1600;
-  const displayHeight = hasDimensions ? image.height! : 1066;
+  const displayWidth = typeof image.width === 'number' && image.width > 0 ? image.width : 1600;
+  const displayHeight = typeof image.height === 'number' && image.height > 0 ? image.height : 1066;
 
   const modalContent = (
     // Overlay


### PR DESCRIPTION
## 概要

定期コード品質チェック（2026-05-06）で発見した問題を修正します。

## 修正内容

### 🔒 セキュリティ

**CSP をプロダクション環境で強制モードに変更**
- `backend/config/initializers/content_security_policy.rb`
- `content_security_policy_report_only = true` のままでは、本番環境でもCSP違反をブロックせずレポートするだけになっていた
- プロダクションでは強制（`enforce`）、その他の環境では引き続き `report-only` に変更

**E2E テストの認証情報をハードコードから環境変数へ**
- `e2e/tests/auth.setup.ts`
- `admin@example.com` / `password123` がソースコードに直接記述されていた
- `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` 環境変数から読み込み、フォールバックとしてデフォルト値を維持

### 🛡️ 型安全性

**`ImageModal.tsx` の不要な非nullアサーション（`!`）を除去**
- `frontend/src/app/gallery/_components/ImageModal.tsx`
- `hasDimensions` という中間変数でガードしたあと `image.width!` / `image.height!` と非nullアサーションを使っていた
- TypeScript はboolean変数によるガードを型narrowingできないため `!` が必要になっていたが、条件式を直接インライン化することで `!` 不要に

### ♻️ コード重複排除

**APIコントローラの `file_dimensions` ロジックを共通ヘルパーに抽出**
- `backend/app/controllers/application_controller.rb`（追加）
- `backend/app/controllers/api/images_controller.rb`
- `backend/app/controllers/api/projects_controller.rb`
- `ImagesController#image_json` と `ProjectsController#project_json` の両方に同じ `metadata = attachment.attached? ? attachment.metadata : {}` パターンが重複していた
- `ApplicationController#file_dimensions(attachment)` として共通化

## テスト方針

- [ ] 既存のRSpecテストが通ること
- [ ] フロントエンドの型チェック（`tsc --noEmit`）が通ること
- [ ] 画像モーダルで幅・高さあり/なし両パターンの表示が正常なこと
- [ ] 本番ビルドでCSP違反がブロックされることを確認（Staging環境で検証推奨）

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzAZbpa37JijhrvkLcAgM9)_