### PR TITLE
fix: コード品質改善 - CSP nonce・React key・不要コメント

### DIFF
--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -49,7 +49,7 @@ class Admin::ImagesController < Admin::Base
   end
 
   def insert_at
-    position = insert_params.to_i # require(:position)は直接値を返すので、[:position]は不要
+    position = insert_params.to_i
     @image.row_order_position = position
     if @image.save
       head :ok

--- a/backend/config/initializers/content_security_policy.rb
+++ b/backend/config/initializers/content_security_policy.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   end
 
   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Enforce in production; report-only in other environments to verify policy changes safely.

--- a/frontend/src/app/_components/IntroSection.tsx
+++ b/frontend/src/app/_components/IntroSection.tsx
@@ -54,8 +54,8 @@ export default function IntroSection() {
                 Kakemu Fujii
               </h2>
               <div className="space-y-4 text-base leading-relaxed text-foreground md:text-lg">
-                {INTRO_PARAGRAPHS.map((paragraph) => (
-                  <p key={paragraph}>{paragraph}</p>
+                {INTRO_PARAGRAPHS.map((paragraph, index) => (
+                  <p key={index}>{paragraph}</p>
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## 概要

定期的なコード品質チェックにより発見した問題を修正します。

## 修正内容

### 🔒 セキュリティ: CSP nonce 生成の改善（重要度: MEDIUM）

**ファイル:** `backend/config/initializers/content_security_policy.rb`

**問題:** CSP の nonce 生成に `request.session.id.to_s` を使用していたため、同一セッション内で同じ nonce 値が使い回される。nonce は「一度しか使わない値」であるべきで、セッション ID は予測可能でありセキュリティ上問題がある。

**修正:** `SecureRandom.base64(16)` に変更し、リクエストごとに暗号学的にランダムな nonce を生成するよう修正。

```ruby
# Before
config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }

# After
config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
```

### ⚛️ React: key にコンテンツ文字列を使用している問題（重要度: LOW）

**ファイル:** `frontend/src/app/_components/IntroSection.tsx`

**問題:** `INTRO_PARAGRAPHS.map` で段落の内容をそのまま `key` として使用していた。文字列の内容変更時に React が DOM を再利用する際、意図しない挙動が起きる可能性がある。また React のベストプラクティスとして、リストの key は安定した識別子（index や ID）を使うべき。

**修正:** `key={paragraph}` → `key={index}` に変更。

### 🗑️ 命名・コメント: ミスリーディングなコメントの削除（重要度: LOW）

**ファイル:** `backend/app/controllers/admin/images_controller.rb`

**問題:** `insert_at` アクション内のコメントが誤解を招く内容だったため削除。コードは明瞭なので説明不要。

## チェック観点別の全体評価

| 観点 | 評価 | 備考 |
|------|------|------|
| 未使用コード | ✅ 問題なし | 直近PR(#136)で対応済み |
| 型安全性 | ✅ 概ね良好 | 一部optional chainingで適切に対応済み |
| エラーハンドリング | ✅ 概ね良好 | finally句による確実なローディング解除 |
| セキュリティ | ⚠️ 本PRで修正 | CSP nonce を修正 |
| パフォーマンス | ✅ 概ね良好 | IntersectionObserver等適切に実装済み |
| コード重複 | 🔵 許容範囲 | ProjectCard/ImageGrid のパターンは実装が異なり抽出不要 |
| 命名規則 | ✅ 概ね良好 | 本PRでコメント削除 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwJkRKcG2yEBpWxJtCtYXB)_