### PR TITLE
fix: コード品質改善 - セーフナビゲーション統一・コメント精度改善

### DIFF
--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -49,7 +49,7 @@ class Admin::ImagesController < Admin::Base
   end
 
   def insert_at
-    position = insert_params.to_i # require(:position)は直接値を返すので、[:position]は不要
+    position = insert_params.to_i
     @image.row_order_position = position
     if @image.save
       head :ok

--- a/backend/app/controllers/api/camera_names_controller.rb
+++ b/backend/app/controllers/api/camera_names_controller.rb
@@ -1,5 +1,5 @@
 class Api::CameraNamesController < ApplicationController
-  skip_before_action :verify_authenticity_token # SPA からの呼び出し用
+  skip_before_action :verify_authenticity_token # 管理画面の Stimulus コントローラから fetch で呼び出すため
 
   def create
     make  = params[:make]&.strip

--- a/backend/app/controllers/api/images_controller.rb
+++ b/backend/app/controllers/api/images_controller.rb
@@ -36,7 +36,7 @@ class Api::ImagesController < ApplicationController
       thumbnail: image.thumbnail_url,
       width: width,
       height: height,
-      camera_name: "#{image.camera.manufacturer} #{image.camera.name}".strip,
+      camera_name: "#{image.camera&.manufacturer} #{image.camera&.name}".strip,
       lens_name: image.lens&.name
     )
   end


### PR DESCRIPTION
## 概要

コード品質チェックで発見した3点を修正します。

## 変更内容

### 1. `api/images_controller.rb` — カメラのセーフナビゲーション統一（MEDIUM）

`image_json` メソッド内で `image.lens&.name` はセーフナビゲーションを使用しているにもかかわらず、同じ行の `image.camera.manufacturer` / `image.camera.name` はダイレクトアクセスになっていた不整合を修正。

DBの外部キー制約と `Camera#has_many :images, dependent: :restrict_with_error` により `camera` が `nil` になることは実運用上ほぼあり得ないが、`lens` と一貫性のある防御的コーディングに統一します。

```ruby
# Before
camera_name: "#{image.camera.manufacturer} #{image.camera.name}".strip,

# After
camera_name: "#{image.camera&.manufacturer} #{image.camera&.name}".strip,
```

### 2. `api/camera_names_controller.rb` — CSRF スキップ理由のコメント修正（LOW）

「SPA からの呼び出し用」というコメントが実態と異なっていた（実際は管理画面の Stimulus コントローラから fetch で呼び出している）ため、正確な説明に修正。

### 3. `admin/images_controller.rb` — 誤解を招くコメント削除（LOW）

`insert_at` アクション内のコメントが `params.require()` の動作に関して誤解を招く内容だったため削除。

## チェック観点

- [x] 型安全性・防御的コーディング
- [x] コメントの正確性
- [x] 既存テストへの影響なし（ロジック変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1EGBrnncy9U9p6zqBdyHY)_