### PR TITLE
fix: エラーハンドリング・アクセシビリティの改善（コード品質チェック 2026-05-25）

### DIFF
--- a/frontend/src/app/_components/IntroSection.tsx
+++ b/frontend/src/app/_components/IntroSection.tsx
@@ -54,8 +54,8 @@ export default function IntroSection() {
                 Kakemu Fujii
               </h2>
               <div className="space-y-4 text-base leading-relaxed text-foreground md:text-lg">
-                {INTRO_PARAGRAPHS.map((paragraph, index) => (
-                  <p key={index}>{paragraph}</p>
+                {INTRO_PARAGRAPHS.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
                 ))}
               </div>
             </div>

--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -67,6 +67,8 @@ export default function GalleryApp({
           setHasMore(result.hasMore);
           setFetchError(result.error);
         }
+      } catch {
+        if (isActive) setFetchError(true);
       } finally {
         if (isActive) {
           setIsLoadingImages(false);
@@ -99,6 +101,8 @@ export default function GalleryApp({
       } else {
         setFetchError(true);
       }
+    } catch {
+      setFetchError(true);
     } finally {
       setIsLoadingMore(false);
     }

--- a/frontend/src/app/gallery/_components/ImageModal.tsx
+++ b/frontend/src/app/gallery/_components/ImageModal.tsx
@@ -166,7 +166,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
           }}
         >
           <span className="flex h-10 w-10 items-center justify-center rounded-full bg-black/30 text-white transition group-hover:bg-black/60">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5"><polyline points="15 18 9 12 15 6" /></svg>
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5"><polyline points="15 18 9 12 15 6" /></svg>
           </span>
         </button>
       )}
@@ -181,7 +181,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
           }}
         >
           <span className="flex h-10 w-10 items-center justify-center rounded-full bg-black/30 text-white transition group-hover:bg-black/60">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5"><polyline points="9 6 15 12 9 18" /></svg>
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5"><polyline points="9 6 15 12 9 18" /></svg>
           </span>
         </button>
       )}


### PR DESCRIPTION
## 概要

コード品質チェックで発見した問題のうち、修正可能なものを対応しました。

## 変更内容

### 🔴 エラーハンドリング（HIGH）

**`GalleryApp.tsx`** — `load()` / `loadMore()` に `catch` ブロックを追加

- 従来は `try/finally` のみで `catch` がなく、`fetchImages` が予期しない例外を投げた場合にユーザーへのエラー表示（`setFetchError(true)`）がスキップされていた
- 明示的な `catch` を追加し、例外発生時も `fetchError` ステートが正しくセットされるよう修正

### 🟡 コードパターン（MEDIUM）

**`IntroSection.tsx`** — React key に array index を使う anti-pattern を修正

- `key={index}` → `key={paragraph}` に変更（静的な文字列なので段落テキスト自体が一意キーとして使用可能）

### 🟢 アクセシビリティ（LOW）

**`ImageModal.tsx`** — ナビゲーション矢印 SVG に `aria-hidden="true"` を追加

- 前/次ボタンの装飾用 SVG にスクリーンリーダーが不要なマークアップを読み上げないよう対応
- 各 `<button>` には既に `aria-label="Previous"` / `aria-label="Next"` があるため、内部 SVG は隠して問題なし

## チェック観点別サマリー（修正対象外含む）

| 観点 | 発見数 | 対応 |
|------|--------|------|
| 未使用コード | 0 | — |
| 型安全性 | 1（ProjectCard の型アサーション） | 標準的パターンにつき対応不要と判断 |
| エラーハンドリング | 2 | ✅ 本PRで修正 |
| セキュリティ | 1（CSPヘッダー未設定） | インフラ対応のためスコープ外 |
| パフォーマンス | 1（`gridStyles` 毎レンダー再生成） | 定数オブジェクトのため実害なし |
| コード重複 | 0 | — |
| 命名規則 | 0 | — |
| アクセシビリティ | 1 | ✅ 本PRで修正 |
| React patterns | 1（index key） | ✅ 本PRで修正 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnwBKpBtVf2wMKXzuwGcxR)_