### PR TITLE
fix: コード品質改善（認可レスポンス・カテゴリ順序・parseInt基数）

### DIFF
--- a/backend/app/controllers/admin/base.rb
+++ b/backend/app/controllers/admin/base.rb
@@ -15,6 +15,10 @@ class Admin::Base < ApplicationController
   def check_admin
     return if current_user&.role_admin?
 
-    render json: { error: 'You are not authorized to perform this action.' }, status: :unauthorized
+    respond_to do |format|
+      format.html { redirect_to root_path, alert: '管理者権限がありません。' }
+      format.json { render json: { error: 'You are not authorized to perform this action.' }, status: :unauthorized }
+      format.any  { head :unauthorized }
+    end
   end
 end

--- a/backend/app/controllers/api/categories_controller.rb
+++ b/backend/app/controllers/api/categories_controller.rb
@@ -1,6 +1,6 @@
 class Api::CategoriesController < ApplicationController
   def index
-    categories = Category.all
+    categories = Category.order(:name)
     render json: categories.map(&:as_json)
   end
 end

--- a/backend/app/javascript/controllers/exif_auto_reader_controller.js
+++ b/backend/app/javascript/controllers/exif_auto_reader_controller.js
@@ -103,7 +103,7 @@ export default class extends Controller {
       const offsetMatch = offsetTime.match(/([+-])(\d{2}):(\d{2})/)
       if (offsetMatch) {
         const [, sign, offsetHours, offsetMinutes] = offsetMatch
-        const offsetMinutesTotal = parseInt(offsetHours) * 60 + parseInt(offsetMinutes)
+        const offsetMinutesTotal = parseInt(offsetHours, 10) * 60 + parseInt(offsetMinutes, 10)
         const offsetMs = (sign === '+' ? -offsetMinutesTotal : offsetMinutesTotal) * 60 * 1000
 
         const date = new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}Z`)

--- a/frontend/src/app/_components/GallerySection.tsx
+++ b/frontend/src/app/_components/GallerySection.tsx
@@ -1,4 +1,3 @@
-
 'use client';
 
 import Link from 'next/link';

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,3 @@
-
 import SiteHeader from './_components/SiteHeader';
 import HeroSection from './_components/HeroSection';
 import IntroSection from './_components/IntroSection';


### PR DESCRIPTION
## 概要

コード品質チェックで発見した問題を修正します。

## 変更内容

### 🔴 `Admin::Base#check_admin` — HTML リクエストへの不適切な JSON 応答
- **問題**: 非管理者ユーザーが管理画面にアクセスした際、HTML リクエストにも関わらず JSON が返されていた
- **修正**: `respond_to` でリクエスト形式を判定し、HTML は `root_path` へリダイレクト、JSON エンドポイント（lookup、insert_at 等）は 401 JSON を維持

### 🟡 `Api::CategoriesController` — カテゴリの順序が非決定的
- **問題**: `Category.all` に明示的な ORDER BY がなく、データベースの返す順序に依存していた
- **修正**: `Category.order(:name)` でアルファベット昇順に固定

### 🟡 `exif_auto_reader_controller.js` — `parseInt` に基数省略
- **問題**: `parseInt(offsetHours)` のように基数を省略していた（ESLint の `radix` ルール違反）
- **修正**: 基数 10 を明示（`parseInt(offsetHours, 10)`）

### ⚪ `GallerySection.tsx`, `page.tsx` — ファイル先頭の余分な空行
- ファイル先頭の空行を除去

## テスト観点

- 管理者ユーザーは従来通り管理画面にアクセス可能
- 非管理者ユーザーがブラウザで管理画面にアクセスするとルートページにリダイレクト
- Stimulus の fetch 呼び出し（カメラ/レンズ lookup、画像並び替え）は引き続き JSON 401 を受信
- カテゴリ一覧 API のレスポンスが名前順で返される

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAN6TtApzNv6tjQ4UbWHGY)_