### PR TITLE
fix: 型専用インポートに import type を使用（isolatedModules 準拠）

### DIFF
--- a/frontend/src/app/gallery/_components/CategoryCheckbox.tsx
+++ b/frontend/src/app/gallery/_components/CategoryCheckbox.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { CategoryType } from '@/utils/types';
+import type { CategoryType } from '@/utils/types';
 
 type CategoryCheckboxProps = {
   category: CategoryType;

--- a/frontend/src/app/gallery/_components/ImageFilter.tsx
+++ b/frontend/src/app/gallery/_components/ImageFilter.tsx
@@ -1,4 +1,4 @@
-import { CategoryType } from '@/utils/types';
+import type { CategoryType } from '@/utils/types';
 import CategoryCheckbox from './CategoryCheckbox';
 
 type ImageFilterProps = {

--- a/frontend/src/app/gallery/_components/ImageGrid.tsx
+++ b/frontend/src/app/gallery/_components/ImageGrid.tsx
@@ -2,7 +2,7 @@
 
 import { memo, type KeyboardEvent, type SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
-import { ImageType } from '@/utils/types';
+import type { ImageType } from '@/utils/types';
 import Loading from '@/ui/Loading';
 
 const GridImage = memo(function GridImage({ src, fallbackSrc, alt, width, height }: {

--- a/frontend/src/app/gallery/_components/ImageModal.tsx
+++ b/frontend/src/app/gallery/_components/ImageModal.tsx
@@ -3,7 +3,7 @@
 import { type SyntheticEvent, useCallback, useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import Image from 'next/image';
-import { ImageType } from '@/utils/types';
+import type { ImageType } from '@/utils/types';
 import { useIsClient } from '@/hooks/useIsClient';
 
 const FOCUSABLE_SELECTORS =
@@ -151,7 +151,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
           onClose();
         }}
       >
-        {'\u00D7'}
+        {'×'}
       </button>
 
       {/* Navigation zones — tall hit areas along left/right edges */}

--- a/frontend/src/app/projects/_components/ProjectCard.tsx
+++ b/frontend/src/app/projects/_components/ProjectCard.tsx
@@ -2,7 +2,7 @@
 
 import { type SyntheticEvent, useCallback, useState } from 'react';
 import Image from 'next/image';
-import { ProjectType } from '@/utils/types';
+import type { ProjectType } from '@/utils/types';
 
 type ProjectCardProps = {
   project: ProjectType;

--- a/frontend/src/hooks/categoryApi.ts
+++ b/frontend/src/hooks/categoryApi.ts
@@ -1,5 +1,5 @@
-import { apiFetch, ApiRequestInit } from '@/utils/api';
-import { CategoryType } from '@/utils/types';
+import { apiFetch, type ApiRequestInit } from '@/utils/api';
+import type { CategoryType } from '@/utils/types';
 
 type FetchCategoriesOptions = {
   fetchInit?: ApiRequestInit;

--- a/frontend/src/hooks/imageApi.ts
+++ b/frontend/src/hooks/imageApi.ts
@@ -1,5 +1,5 @@
-import { apiFetch, ApiRequestInit } from '@/utils/api';
-import { PaginatedImages } from '@/utils/types';
+import { apiFetch, type ApiRequestInit } from '@/utils/api';
+import type { PaginatedImages } from '@/utils/types';
 
 type FetchImagesOptions = {
   categoryIds?: number[];

--- a/frontend/src/hooks/projectApi.ts
+++ b/frontend/src/hooks/projectApi.ts
@@ -1,5 +1,5 @@
-import { apiFetch, ApiRequestInit } from '@/utils/api';
-import { ProjectType } from '@/utils/types';
+import { apiFetch, type ApiRequestInit } from '@/utils/api';
+import type { ProjectType } from '@/utils/types';
 
 type FetchProjectsOptions = {
   fetchInit?: ApiRequestInit;


### PR DESCRIPTION
## 概要

`tsconfig.json` に `"isolatedModules": true` が設定されているにもかかわらず、型のみに使用するインポートで `import type` が使われていなかった箇所を修正します。

`import type` を使うことで：
- トランスパイラがコンパイル時に型インポートを安全に削除できる
- バンドラーのツリーシェイキングの精度が向上する
- 型 vs 値のインポートの意図が明確になる

## 変更ファイル（8件）

| ファイル | 変更内容 |
|---|---|
| `hooks/imageApi.ts` | `PaginatedImages` → `import type`、`ApiRequestInit` → inline `type` |
| `hooks/categoryApi.ts` | `CategoryType` → `import type`、`ApiRequestInit` → inline `type` |
| `hooks/projectApi.ts` | `ProjectType` → `import type`、`ApiRequestInit` → inline `type` |
| `gallery/_components/ImageModal.tsx` | `ImageType` → `import type` |
| `gallery/_components/ImageGrid.tsx` | `ImageType` → `import type` |
| `gallery/_components/ImageFilter.tsx` | `CategoryType` → `import type` |
| `gallery/_components/CategoryCheckbox.tsx` | `CategoryType` → `import type` |
| `projects/_components/ProjectCard.tsx` | `ProjectType` → `import type` |

## 変更例

```diff
- import { apiFetch, ApiRequestInit } from '@/utils/api';
- import { PaginatedImages } from '@/utils/types';
+ import { apiFetch, type ApiRequestInit } from '@/utils/api';
+ import type { PaginatedImages } from '@/utils/types';
```

## 動作への影響

なし。型情報はランタイムには存在しないため、ビルド出力・動作は変わりません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMSaMUcjp3w6GaKFY7mTte)_