### PR TITLE
fix: flash.now修正・不要なCSRFスキップ削除によるセキュリティ改善

### DIFF
--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -34,8 +34,8 @@ class Admin::ImagesController < Admin::Base
     if @image.save
       redirect_to admin_images_path(@image, format: nil), notice: 'Image was successfully updated.'
     else
-      flash[:alert] = 'Image failed to update.'
-      Rails.logger.debug { "Image failed to update.#{@image.errors.full_messages}" }
+      flash.now[:alert] = 'Image failed to update.'
+      Rails.logger.debug { "Image failed to update: #{@image.errors.full_messages.join(', ')}" }
       render :edit, status: :unprocessable_content
     end
   end

--- a/backend/app/controllers/api/camera_names_controller.rb
+++ b/backend/app/controllers/api/camera_names_controller.rb
@@ -1,5 +1,4 @@
 class Api::CameraNamesController < ApplicationController
-  skip_before_action :verify_authenticity_token # 管理画面の Stimulus コントローラから fetch で呼び出すため
   before_action :authenticate_user!
 
   def create


### PR DESCRIPTION
## 概要

コード品質チェックで発見した2件のバグ・セキュリティ問題を修正します。

## 修正内容

### 1. `Admin::ImagesController#update` — `flash` → `flash.now` バグ修正

**問題:** `update` アクションの失敗時に `flash[:alert]` を使用していたため、`render :edit` でも次のリクエストまでエラーメッセージが残り続けるバグがあった。`create` アクションでは正しく `flash.now[:alert]` が使われているが、`update` だけ漏れていた。

**修正:** `flash[:alert]` → `flash.now[:alert]` に変更。合わせてログメッセージのフォーマットも改善（配列の `.join(', ')` を追加）。

### 2. `Api::CameraNamesController` — 不要な `skip_before_action :verify_authenticity_token` を削除

**問題:** `skip_before_action :verify_authenticity_token` が設定されており、CSRF保護が無効になっていた。コメントには「Stimulusコントローラから fetch で呼び出すため」とあるが、実際の Stimulus コントローラ (`exif_auto_reader_controller.js`) を確認したところ、リクエスト時に `X-CSRF-Token` ヘッダを正しく送信しており、スキップは不要だった。

**修正:** `skip_before_action` を削除し、CSRF保護を有効化。Stimulusコントローラ側の変更は不要（既に対応済み）。

## 確認事項

- [x] `flash.now` で `render :edit` 時のみエラーが表示される
- [x] Stimulus コントローラが `X-CSRF-Token` ヘッダを送信していることを確認
- [x] 既存のリクエストスペックへの影響がないことを確認

## 修正対象ファイル

- `backend/app/controllers/admin/images_controller.rb`
- `backend/app/controllers/api/camera_names_controller.rb`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNUDGKTq71FvJfGh8tq75b)_