### PR TITLE
fix(backend): ruby-vips を明示依存に追加し E2E の vips ロードエラーを解消

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -53,6 +53,8 @@ gem "haml-rails"
 gem "devise"
 
 gem "image_processing", "~> 2.0"
+# image_processing 2.0 dropped its automatic ruby-vips dependency, so declare it explicitly
+gem "ruby-vips", "~> 2.2"
 
 gem "aws-sdk-s3", "~> 1.225"
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -134,6 +134,12 @@ GEM
       railties (>= 6.1.0)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     globalid (1.3.0)
       activesupport (>= 6.1)
     haml (7.2.0)
@@ -325,6 +331,9 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     securerandom (0.4.1)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
@@ -397,6 +406,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby-vips (~> 2.2)
   shoulda-matchers
   sprockets-rails
   stimulus-rails


### PR DESCRIPTION
## 原因

main の E2E Tests が継続的に失敗していた。`e2e:seed` の variant 処理（`analyze_and_warm_variants`）で以下のエラー:

```
LoadError: cannot load such file -- vips
  image_processing/vips.rb:3:in `<main>'
```

PR #169 で `image_processing` が **1.14.0 → 2.0.1** にbumpされた際、1.x では実行時依存に含まれていた `ruby-vips` が 2.0 で外れた（Gemfile.lock の `image_processing (2.0.1)` にネスト依存が無いことで確認）。結果 `require "vips"` が解決できず失敗していた。

## 修正

`ruby-vips` を Gemfile に明示追加（`~> 2.2`）。CI は既に `libvips-dev` を apt で入れているため追加対応は不要。

## 検証

- `bundle install` で `ruby-vips (2.3.0)` がlockに追加（linux向け ffi バイナリ含む）
- `bundle exec ruby -e 'require "image_processing/vips"'` → ロード成功（vips 8.18.2）

> [!NOTE]
> production も同じ依存を使うため、この修正は本番の variant 生成の破綻も併せて防ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)