### PR TITLE
fix(backend): 非管理者の HTML アクセスで root_path 未定義の 500 を解消

### DIFF
--- a/backend/app/controllers/admin/base.rb
+++ b/backend/app/controllers/admin/base.rb
@@ -15,9 +15,10 @@ class Admin::Base < ApplicationController
   def check_admin
     return if current_user&.role_admin?
 
+    message = 'You are not authorized to perform this action.'
     respond_to do |format|
-      format.html { redirect_to root_path, alert: '管理者権限がありません。' }
-      format.json { render json: { error: 'You are not authorized to perform this action.' }, status: :unauthorized }
+      format.html { render plain: message, status: :unauthorized }
+      format.json { render json: { error: message }, status: :unauthorized }
       format.any  { head :unauthorized }
     end
   end

--- a/backend/spec/requests/admin/access_spec.rb
+++ b/backend/spec/requests/admin/access_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin access control', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  describe 'GET /admin as a guest user' do
+    before { sign_in create(:user, role: 'guest') }
+
+    it 'returns 401 with the unauthorized message for HTML requests' do
+      get '/admin'
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).to include('You are not authorized to perform this action.')
+    end
+
+    it 'returns 401 JSON for JSON requests' do
+      get '/admin', headers: { 'Accept' => 'application/json' }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body['error']).to eq('You are not authorized to perform this action.')
+    end
+  end
+
+  describe 'GET /admin as an unauthenticated user' do
+    it 'redirects to the sign in page' do
+      get '/admin'
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end


### PR DESCRIPTION
## 原因

vips 修正 (#192) で E2E が seed を越えて進めるようになった結果、別のリグレッションが顕在化した。

`guest user cannot access /admin` テストが 500 で失敗:

```
Puma caught this error: undefined local variable or method `root_path' for an instance of Admin::IndexController (NameError)
  app/controllers/admin/base.rb:19:in `block (2 levels) in check_admin'
```

PR #175 で `check_admin` の認可失敗応答が単純な JSON render から `respond_to` に変更され、HTML 分岐に `redirect_to root_path` が追加された。しかし本アプリには top-level `root` ルートが無く（`namespace :admin` 内の `admin_root` のみ）、`root_path` ヘルパが未定義のため HTML ナビゲーションで NameError → 500 になっていた。

公開 root ページは Next.js 側にあり、Rails 側にリダイレクト先が存在しないため、`redirect_to root_path` は元々成立しない設計だった。vips エラーが seed 段階で先に落ちていたため、このバグはこれまでマスクされていた。

## 修正

- HTML 分岐も `redirect_to` をやめ、401 + 認可エラーメッセージ（`You are not authorized to perform this action.`）を返す。JSON/any 分岐は従来どおり。
- 同種のリグレッションが E2E だけでなく **Backend CI（RSpec）** でも捕捉されるよう、`spec/requests/admin/access_spec.rb` を追加（guest の HTML/JSON 401・未認証の sign_in リダイレクトを検証）。

## 検証（ローカル）

- `rspec spec/requests/admin/access_spec.rb` → 3 examples, 0 failures
- `rspec spec/requests/admin/images_spec.rb`（admin ハッピーパス）→ 0 failures
- `rubocop` → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)