### PR TITLE
refactor(frontend): SiteHeader に統一し、未使用 props を削除

### DIFF
--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
-import Header from '@/ui/Header';
-import { HEADER_STYLE_PRESETS } from '@/ui/headerStyles';
+import SiteHeader from '../_components/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'Contact',
@@ -9,7 +8,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
-      <Header styles={HEADER_STYLE_PRESETS.solid} />
+      <SiteHeader />
       <main className="min-h-screen bg-background flex flex-col items-center justify-center px-6 text-center">
         <span className="text-xs tracking-[0.3em] text-foreground/50 uppercase">Contact</span>
         <h1 className="mt-4 text-3xl md:text-4xl font-semibold text-foreground">Work in Progress</h1>

--- a/frontend/src/app/gallery/_components/ImageGrid.tsx
+++ b/frontend/src/app/gallery/_components/ImageGrid.tsx
@@ -83,7 +83,6 @@ type ImageGridProps = {
   isLoadingMore?: boolean;
   hasMore?: boolean;
   onLoadMore?: () => void;
-  isInteractive?: boolean;
 };
 
 export default function ImageGrid({
@@ -93,7 +92,6 @@ export default function ImageGrid({
   isLoadingMore = false,
   hasMore = false,
   onLoadMore,
-  isInteractive = true,
 }: ImageGridProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -144,7 +142,7 @@ export default function ImageGrid({
     return <Loading label="Loading images..." className="py-20" />;
   }
 
-  const isClickable = Boolean(onFocus) && isInteractive;
+  const isClickable = Boolean(onFocus);
   const columnWidth = getColumnWidth(containerWidth);
   const gridStyles = { gridAutoRows: `${ROW_HEIGHT_PX}px` } as const;
 

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
-import Header from '@/ui/Header';
-import { HEADER_STYLE_PRESETS } from '@/ui/headerStyles';
+import SiteHeader from '../_components/SiteHeader';
 import GalleryApp from './_components/GalleryApp';
 import { fetchCategories } from '@/hooks/categoryApi';
 import { fetchImages } from '@/hooks/imageApi';
@@ -17,7 +16,7 @@ export default async function Page() {
 
   return (
     <>
-      <Header styles={HEADER_STYLE_PRESETS.solid} />
+      <SiteHeader />
       <div className="min-h-screen bg-background pt-20 md:pt-24">
         <GalleryApp
           initialCategories={categoriesResult.categories}


### PR DESCRIPTION
## 概要

コード品質チェック（2026-06-15）で発見した以下の問題を修正します。

### 修正内容

#### 1. ヘッダーコンポーネントの不統一を解消
- `gallery/page.tsx` と `contact/page.tsx` で `<Header styles={HEADER_STYLE_PRESETS.solid} />` を直接使用していた
- `page.tsx`（ホーム）と `projects/page.tsx` はすでに `<SiteHeader />` を使用していた
- すべてのページで `<SiteHeader />` に統一することで、ヘッダーロジックの変更が一箇所で完結するようになる

#### 2. `ImageGrid` の未使用 `isInteractive` prop を削除
- `isInteractive` prop が宣言されていたが、全呼び出し元（`GalleryApp`、`GallerySection`）で設定されておらず、常にデフォルト値 `true` が使用されていた
- `isClickable` の計算は `Boolean(onFocus) && isInteractive` だったが `isInteractive` は常に `true` のため `Boolean(onFocus)` と等価だった
- prop を削除して `const isClickable = Boolean(onFocus)` に簡略化

## テスト観点

- ギャラリーページのヘッダーが solid スタイルで表示されること
- コンタクトページのヘッダーが solid スタイルで表示されること
- ギャラリーグリッドで画像クリック（モーダル表示）が正常に動作すること
- ギャラリーグリッドでプレビュー表示（クリック不可）が正常に動作すること

---
_Generated by [Claude Code](https://claude.ai/code/session_01SE1SJWfEppa8Ui1cxt2R1D)_