### PR TITLE
fix(images): 原寸配信をやめ1920px display variantで配信する

### DIFF
--- a/backend/app/controllers/api/images_controller.rb
+++ b/backend/app/controllers/api/images_controller.rb
@@ -32,7 +32,7 @@ class Api::ImagesController < ApplicationController
     width, height = file_dimensions(image.file)
 
     image.as_json(except: %i[camera_id lens_id]).merge(
-      file: image.file_url,
+      file: image.display_url,
       thumbnail: image.thumbnail_url,
       width: width,
       height: height,

--- a/backend/app/controllers/api/projects_controller.rb
+++ b/backend/app/controllers/api/projects_controller.rb
@@ -10,7 +10,7 @@ class Api::ProjectsController < ApplicationController
     width, height = file_dimensions(project.file)
 
     project.as_json(only: %i[id title link]).merge(
-      file: project.file_url,
+      file: project.display_url,
       thumbnail: project.thumbnail_url,
       width: width,
       height: height

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -5,7 +5,7 @@ module CdnAttachedFile
 
   included do
     after_commit :analyze_attached_file, on: %i[create update]
-    after_commit :warm_thumbnail_variant, on: %i[create update]
+    after_commit :warm_variants, on: %i[create update]
   end
 
   def file_url
@@ -14,27 +14,33 @@ module CdnAttachedFile
     build_cdn_url(file.key) || active_storage_url_for(file)
   end
 
-  def thumbnail_variant
-    return unless file.attached?
+  def thumbnail_variant = variant_for(thumbnail_limit)
 
-    file.variant(resize_to_limit: thumbnail_limit)
-  end
-
-  def thumbnail_url
-    variant = thumbnail_variant
-    return unless variant
-
-    ensure_thumbnail_variant_processed(variant)
-
-    build_cdn_url(variant.key) || active_storage_url_for(variant)
-  rescue StandardError, LoadError => e
-    Rails.logger.warn "thumbnail_url fallback (#{log_reference}): #{e.class} #{e.message}"
-    file_url
-  end
+  def thumbnail_url = variant_url(thumbnail_limit)
+  def display_url = variant_url(display_limit)
 
   private
 
+  def variant_for(limit)
+    return unless file.attached?
+
+    file.variant(resize_to_limit: limit)
+  end
+
+  def variant_url(limit)
+    variant = variant_for(limit)
+    return unless variant
+
+    ensure_variant_processed(variant)
+
+    build_cdn_url(variant.key) || active_storage_url_for(variant)
+  rescue StandardError, LoadError => e
+    Rails.logger.warn "variant_url fallback (#{log_reference}): #{e.class} #{e.message}"
+    file_url
+  end
+
   def thumbnail_limit = self.class::THUMBNAIL_LIMIT
+  def display_limit = self.class::DISPLAY_LIMIT
 
   def analyze_attached_file
     return unless file.attached?
@@ -47,19 +53,19 @@ module CdnAttachedFile
     Rails.logger.error "analyze_attached_file failed (#{log_reference}): #{e.class} #{e.message}"
   end
 
-  def warm_thumbnail_variant
+  def warm_variants
     return unless file.attached?
 
-    variant = thumbnail_variant
-    return if variant.blank?
-
-    ensure_thumbnail_variant_processed(variant)
+    [thumbnail_limit, display_limit].each do |limit|
+      variant = variant_for(limit)
+      ensure_variant_processed(variant) if variant
+    end
   rescue ActiveStorage::FileNotFoundError => e
-    log_file_not_found(:warm_thumbnail_variant, e)
+    log_file_not_found(:warm_variants, e)
   rescue LoadError => e
-    Rails.logger.warn "thumbnail_variant skipped (#{log_reference}): #{e.message}"
+    Rails.logger.warn "variant warm skipped (#{log_reference}): #{e.message}"
   rescue StandardError => e
-    Rails.logger.error "thumbnail_variant error (#{log_reference}): #{e.full_message}"
+    Rails.logger.error "variant warm error (#{log_reference}): #{e.full_message}"
   end
 
   def log_reference = "#{self.class.name.underscore} #{id}"
@@ -105,11 +111,11 @@ module CdnAttachedFile
     nil
   end
 
-  def ensure_thumbnail_variant_processed(variant)
-    return variant if thumbnail_variant_generated?(variant)
+  def ensure_variant_processed(variant)
+    return variant if variant_generated?(variant)
 
-    with_thumbnail_lock do
-      variant.processed unless thumbnail_variant_generated?(variant)
+    with_variant_lock do
+      variant.processed unless variant_generated?(variant)
     end
 
     variant
@@ -117,11 +123,11 @@ module CdnAttachedFile
     variant
   end
 
-  def thumbnail_variant_generated?(variant)
+  def variant_generated?(variant)
     variant.respond_to?(:image) && variant.image&.attached?
   rescue NoMethodError
     false
   end
 
-  def with_thumbnail_lock(&) = persisted? ? with_lock(&) : yield
+  def with_variant_lock(&) = persisted? ? with_lock(&) : yield
 end

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -4,6 +4,7 @@ class Image < ApplicationRecord
 
   ranks :row_order
   THUMBNAIL_LIMIT = [960, 960].freeze
+  DISPLAY_LIMIT = [1920, 1920].freeze
 
   has_many :image_categories, dependent: :destroy
   has_many :categories, through: :image_categories

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -2,6 +2,7 @@ class Project < ApplicationRecord
   include CdnAttachedFile
 
   THUMBNAIL_LIMIT = [1440, 1440].freeze
+  DISPLAY_LIMIT = [1920, 1920].freeze
 
   has_one_attached :file, dependent: :purge_later
 

--- a/backend/app/views/admin/images/_image_row.html.haml
+++ b/backend/app/views/admin/images/_image_row.html.haml
@@ -4,7 +4,7 @@
     %span.order-number= (image.row_order_rank || 0) + 1
   %td
     - if image.file.attached?
-      = image_tag(image.file, alt: "#{image.title} preview", style: "height: 100px; width: auto;")
+      = image_tag(image.thumbnail_variant, alt: "#{image.title} preview", style: "height: 100px; width: auto;")
     - else
       %span.text-muted プレビューなし
   %td= image.title

--- a/backend/app/views/admin/images/show.html.haml
+++ b/backend/app/views/admin/images/show.html.haml
@@ -1,7 +1,7 @@
 %h1 画像詳細
 - if @image.file.attached?
   .mb-3
-    = image_tag @image.file, class: 'img-fluid img-thumbnail', style: 'max-width: 300px;'
+    = image_tag @image.thumbnail_variant, class: 'img-fluid img-thumbnail', style: 'max-width: 300px;'
 - else
   %p.text-muted No image attached.
 .row.py-1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,6 +47,9 @@ services:
     environment:
       NODE_ENV: production
       API_BASE_URL: http://backend:3000/api
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
+      NEXT_PUBLIC_CLOUDFRONT_BASE_URL: ${NEXT_PUBLIC_CLOUDFRONT_BASE_URL}
+      NEXT_PUBLIC_S3_HOSTNAME: ${NEXT_PUBLIC_S3_HOSTNAME:-}
     depends_on:
       - backend
     networks:


### PR DESCRIPTION
## 背景

admin 画像一覧で、アップロード画像が**原寸（長辺6000px・約8MB）でブラウザにDL**されていた。`image_tag(image.file)` で原寸 blob を直参照し、CSS (`height: 100px`) で見た目だけ縮めていたのが原因。variant 機構（`CdnAttachedFile`）は既にあるのに admin が使っていなかった。

あわせて、本番でフロントが CDN 画像 URL を解決できていなかった `docker-compose.prod.yml` の env 不足も修正する。

## 変更内容

- **`CdnAttachedFile` を汎用 variant 化** — `thumbnail_*` 専用メソッド群を `variant_for(limit)` / `variant_url(limit)` / `warm_variants` に一般化し、960px サムネに加えて**長辺1920pxの display variant** を生成・warm対象に追加
- **API(images/projects)** の `file` を原寸 `file_url` → `display_url`(1920px) に変更。巨大原寸の配信を停止し **S3 egress を削減**（原寸は bucket 保管のみ＝非配信）
- **admin 画像一覧/詳細** を原寸 blob 直参照 → variant 配信に修正
- **docker-compose.prod** — frontend に `NEXT_PUBLIC_API_BASE_URL` / `NEXT_PUBLIC_CLOUDFRONT_BASE_URL` / `NEXT_PUBLIC_S3_HOSTNAME` を渡し、本番でフロントが CDN 画像 URL を解決できないバグを修正

## サイズ設計の根拠

S3 はストレージ料はほぼ無視でき、コストの主役は egress（配信量）。よって**原寸はbucketに残しつつ、誰にも原寸を配信しない**方針。Retina フル表示でも耐える長辺 **1920px**（元6000px→約1/5の転送量）を display variant とした。

## 動作確認

- `resize_to_limit` 実測: 元 6594×4396 → thumbnail 960×640 / display **1920×1280**（長辺キャップOK）
- original / 960 / 1920 が**別CDNキーで実生成**されることを確認
- admin ビューが variant の representation URL を描画することを確認
- rubocop / 既存 spec 緑（既存のID衝突1件は本変更前から）

## フォローアップ

- ギャラリーAPIの variant レコード N+1（display追加で1リクエストあたりのチェックが倍化）は別issueで追跡予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)