### PR TITLE
fix(e2e): seedのコールバック抑制を現行名warm_variantsに修正しE2E復旧

### DIFF
--- a/backend/lib/tasks/e2e.rake
+++ b/backend/lib/tasks/e2e.rake
@@ -56,10 +56,10 @@ def seed_project
 end
 
 def suppress_cdn_callbacks
-  Image.skip_callback(:commit, :after, :warm_thumbnail_variant, raise: false)
-  Image.skip_callback(:commit, :after, :analyze_attached_file, raise: false)
-  Project.skip_callback(:commit, :after, :warm_thumbnail_variant, raise: false)
-  Project.skip_callback(:commit, :after, :analyze_attached_file, raise: false)
+  [Image, Project].each do |klass|
+    klass.skip_callback(:commit, :after, :warm_variants)
+    klass.skip_callback(:commit, :after, :analyze_attached_file)
+  end
 end
 
 def analyze_and_warm_variants


### PR DESCRIPTION
## 概要

`E2E Tests` ワークフローが PR #207 マージ以降ずっと red だった原因を修正する。テスト本体ではなく、前段の **`Setup database and seed`（`rails e2e:seed`）が `Errno::ENOENT` で exit 1 し、ジョブ全体が死んでいた**。

## 原因

- PR #207 (`a49c5ac`) で `CdnAttachedFile` の after_commit コールバックを `warm_thumbnail_variant` → `warm_variants` にリネーム。
- `lib/tasks/e2e.rake` の `suppress_cdn_callbacks` は旧名 `:warm_thumbnail_variant` を skip し続けており、`raise: false` がそのズレを握り潰して**抑制が no-op 化**。
- 結果、seed の `image.save!` ×3 で `warm_variants` が走り、続く手動 `analyze_and_warm_variants`（`image.file.analyze`）で原本 blob の disk ファイルが見つからず `Errno::ENOENT`。

#206 で green → コールバックをリネームした #207 以降ずっと red（最新失敗 run 27757302131）という履歴とも一致。

## 変更

- `skip_callback` の対象を現行名 `:warm_variants` に修正
- 将来の名前ズレを黙殺しないよう `raise: false` を除去（fail-loud 化）
- Image/Project の重複を `each` で整理

## 検証（ローカル）

- `RAILS_ENV=test rails e2e:seed` → exit 0（`file=true` / `analyzed=true`、修正前は同コマンドで ENOENT 再現）
- フレッシュDBで `CI=1 npx playwright test`（CI同条件・retries:2）→ **10 passed / 1 flaky**（D&Dソートはリトライで pass）= CI green 相当
- `rubocop lib/tasks/e2e.rake` → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)