### PR TITLE
fix: カメラ・レンズコントローラーの失敗時フラッシュメッセージを追加

### DIFF
--- a/backend/app/controllers/admin/cameras_controller.rb
+++ b/backend/app/controllers/admin/cameras_controller.rb
@@ -19,6 +19,7 @@ class Admin::CamerasController < Admin::Base
     if @camera.save
       redirect_to admin_cameras_path, notice: 'Camera was successfully created.'
     else
+      flash.now[:alert] = 'Camera failed to create.'
       render :new, status: :unprocessable_content
     end
   end
@@ -27,6 +28,7 @@ class Admin::CamerasController < Admin::Base
     if @camera.update(camera_params)
       redirect_to admin_cameras_path, notice: 'Camera was successfully updated.'
     else
+      flash.now[:alert] = 'Camera failed to update.'
       render :edit, status: :unprocessable_content
     end
   end

--- a/backend/app/controllers/admin/lenses_controller.rb
+++ b/backend/app/controllers/admin/lenses_controller.rb
@@ -17,6 +17,7 @@ class Admin::LensesController < Admin::Base
     if @lens.save
       redirect_to admin_lenses_path, notice: 'Lens was successfully created.'
     else
+      flash.now[:alert] = 'Lens failed to create.'
       render :new, status: :unprocessable_content
     end
   end
@@ -25,6 +26,7 @@ class Admin::LensesController < Admin::Base
     if @lens.update(lens_params)
       redirect_to admin_lenses_path, notice: 'Lens was successfully updated.'
     else
+      flash.now[:alert] = 'Lens failed to update.'
       render :edit, status: :unprocessable_content
     end
   end


### PR DESCRIPTION
## 概要

コード品質チェック（2026-06-22）で発見した不整合を修正します。

## 問題

`Admin::CamerasController` と `Admin::LensesController` の `create` / `update` アクションで、バリデーション失敗時に `flash.now[:alert]` が設定されていませんでした。

他の管理コントローラー（`ImagesController`、`CategoriesController`、`ProjectsController`）はすべて一貫して失敗時アラートを設定しているため、不整合な状態でした。

## 修正内容

| ファイル | アクション | 修正内容 |
|---|---|---|
| `admin/cameras_controller.rb` | `create` | `flash.now[:alert] = 'Camera failed to create.'` を追加 |
| `admin/cameras_controller.rb` | `update` | `flash.now[:alert] = 'Camera failed to update.'` を追加 |
| `admin/lenses_controller.rb` | `create` | `flash.now[:alert] = 'Lens failed to create.'` を追加 |
| `admin/lenses_controller.rb` | `update` | `flash.now[:alert] = 'Lens failed to update.'` を追加 |

## テスト観点

- カメラ・レンズの新規作成フォームでバリデーションエラーが発生した際、アラートメッセージが表示されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_015v29eUiykcboWnk3q41Yae)_