### PR TITLE
fix: コード品質改善 - 未使用コード削除・API情報漏洩修正・パフォーマンス改善

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -23,9 +23,6 @@ gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
 
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder"
-
 gem "rack-cors"
 
 gem "ranked-model"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -164,9 +164,6 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.15.1)
-      actionview (>= 7.0.0)
-      activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.19.9)
     language_server-protocol (3.17.0.5)
@@ -396,7 +393,6 @@ DEPENDENCIES
   haml-rails
   image_processing (~> 2.0)
   importmap-rails
-  jbuilder
   pg (~> 1.5)
   puma (>= 6.4)
   rack-cors

--- a/backend/app/controllers/api/images_controller.rb
+++ b/backend/app/controllers/api/images_controller.rb
@@ -27,17 +27,19 @@ class Api::ImagesController < ApplicationController
     end
   end
 
-  # カメラのidとレンズのidを名前に変更して渡す
   def image_json(image)
     width, height = file_dimensions(image.file)
-
-    image.as_json(except: %i[camera_id lens_id]).merge(
+    {
+      id: image.id,
+      title: image.title,
+      caption: image.caption,
+      taken_at: image.taken_at,
       file: image.display_url,
       thumbnail: image.thumbnail_url,
       width: width,
       height: height,
       camera_name: image.camera&.display_label,
       lens_name: image.lens&.name
-    )
+    }
   end
 end

--- a/frontend/src/app/_components/GallerySection.tsx
+++ b/frontend/src/app/_components/GallerySection.tsx
@@ -3,8 +3,7 @@ import ImageGrid from '@/app/gallery/_components/ImageGrid';
 import { fetchImages } from '@/hooks/imageApi';
 
 export default async function GallerySection() {
-  const { images, error } = await fetchImages({ fetchInit: { next: { revalidate: 120 } } });
-  const previewImages = images.slice(0, 9);
+  const { images: previewImages, error } = await fetchImages({ limit: 9, fetchInit: { next: { revalidate: 120 } } });
 
   return (
     <section className="bg-background px-6 py-20 md:py-24 snap-ignore" aria-labelledby="gallery-heading">

--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -59,21 +59,13 @@ export default function GalleryApp({
       setIsLoadingImages(true);
       setFetchError(false);
 
-      try {
-        const result = await fetchImages({ categoryIds: selectedCategoryIds });
-        if (isActive) {
-          setImages(result.images);
-          setNextCursor(result.nextCursor);
-          setHasMore(result.hasMore);
-          setFetchError(result.error);
-        }
-      } catch (error) {
-        console.error('Failed to load images:', error);
-        if (isActive) setFetchError(true);
-      } finally {
-        if (isActive) {
-          setIsLoadingImages(false);
-        }
+      const result = await fetchImages({ categoryIds: selectedCategoryIds });
+      if (isActive) {
+        setImages(result.images);
+        setNextCursor(result.nextCursor);
+        setHasMore(result.hasMore);
+        setFetchError(result.error);
+        setIsLoadingImages(false);
       }
     };
 
@@ -89,25 +81,19 @@ export default function GalleryApp({
     if (isLoadingMore || !hasMore || !nextCursor) return;
 
     setIsLoadingMore(true);
-    try {
-      const result = await fetchImages({
-        categoryIds: selectedCategoryIds,
-        cursor: nextCursor,
-      });
-      if (!result.error) {
-        setImages((prev) => [...prev, ...result.images]);
-        setNextCursor(result.nextCursor);
-        setHasMore(result.hasMore);
-        setFetchError(false);
-      } else {
-        setFetchError(true);
-      }
-    } catch (error) {
-      console.error('Failed to load more images:', error);
+    const result = await fetchImages({
+      categoryIds: selectedCategoryIds,
+      cursor: nextCursor,
+    });
+    if (!result.error) {
+      setImages((prev) => [...prev, ...result.images]);
+      setNextCursor(result.nextCursor);
+      setHasMore(result.hasMore);
+      setFetchError(false);
+    } else {
       setFetchError(true);
-    } finally {
-      setIsLoadingMore(false);
     }
+    setIsLoadingMore(false);
   }, [isLoadingMore, hasMore, nextCursor, selectedCategoryIds]);
 
   const handleCategoryToggle = useCallback((id: number) => {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -7,11 +7,6 @@ const geistSans = localFont({
   variable: "--font-geist-sans",
   weight: "100 900",
 });
-const geistMono = localFont({
-  src: "./fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
 
 export const metadata: Metadata = {
   title: {
@@ -36,7 +31,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} antialiased`}
       >
         {children}
       </body>

--- a/frontend/src/hooks/imageApi.ts
+++ b/frontend/src/hooks/imageApi.ts
@@ -4,6 +4,7 @@ import type { PaginatedImages } from '@/utils/types';
 type FetchImagesOptions = {
   categoryIds?: number[];
   cursor?: string | null;
+  limit?: number;
   fetchInit?: ApiRequestInit;
 };
 
@@ -14,13 +15,16 @@ type FetchImagesResult = {
   error: boolean;
 };
 
-function buildImagesPath(categoryIds: number[] = [], cursor?: string | null): string {
+function buildImagesPath(categoryIds: number[] = [], cursor?: string | null, limit?: number): string {
   const params = new URLSearchParams();
   if (categoryIds.length > 0) {
     params.set('categories', categoryIds.join(','));
   }
   if (cursor) {
     params.set('cursor', cursor);
+  }
+  if (limit !== undefined) {
+    params.set('limit', String(limit));
   }
   const query = params.toString();
   return `/images${query ? `?${query}` : ''}`;
@@ -29,9 +33,10 @@ function buildImagesPath(categoryIds: number[] = [], cursor?: string | null): st
 export async function fetchImages({
   categoryIds = [],
   cursor,
+  limit,
   fetchInit,
 }: FetchImagesOptions = {}): Promise<FetchImagesResult> {
-  const path = buildImagesPath(categoryIds, cursor);
+  const path = buildImagesPath(categoryIds, cursor, limit);
   const result = await apiFetch<PaginatedImages>(path, 'images', fetchInit);
   if (result.error) {
     return { images: [], nextCursor: null, hasMore: false, error: true };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -5,9 +5,7 @@ export type ImageType = {
   taken_at: string | null;
   camera_name: string | null;
   lens_name: string | null;
-  row_order: number;
-  is_published: boolean;
-  file: string; // 画像のURL
+  file: string;
   thumbnail?: string | null;
   width: number | null;
   height: number | null;


### PR DESCRIPTION
## 概要

定期的なコード品質チェックで発見した問題の修正。

## 変更内容

### 未使用コードの削除
- **`jbuilder` gem を削除** (`Gemfile`, `Gemfile.lock`): `.json.jbuilder` ファイルが存在せず、すべてのJSONレスポンスは `render json:` で実装済み。不要な依存関係を削除。
- **GeistMono フォントを削除** (`layout.tsx`): `--font-geist-mono` CSS変数が `globals.css` でもコンポーネントでも参照されていないため、フォントファイルの無駄な読み込みを削除。

### セキュリティ・API設計改善
- **images API レスポンスから内部フィールドを除外** (`api/images_controller.rb`): `as_json(except: ...)` を使用していたため `row_order`, `is_published`, `created_at`, `updated_at` がパブリックAPIに漏洩していた。明示的なハッシュ生成に変更し、公開に必要なフィールドのみを返すように修正。
- **`ImageType` から内部フィールドを削除** (`types.ts`): APIが返さなくなった `row_order`, `is_published` を型定義から削除。

### コード品質改善
- **冗長な try/catch を削除** (`GalleryApp.tsx`): `fetchImages` は内部で全エラーを捕捉して `{ error: boolean }` を返すため例外をスローしない。外側の `try/catch` は実質デッドコードだったため削除。

### パフォーマンス改善
- **GallerySection の不要なデータ取得を削減** (`GallerySection.tsx`, `imageApi.ts`): ホームページのギャラリープレビューは9枚しか表示しないにも関わらず、デフォルト20枚をフェッチして `.slice(0, 9)` していた。`limit: 9` を指定して必要な分だけ取得するように修正。あわせて `fetchImages` に `limit` オプションを追加。

## チェックリスト
- [x] `jbuilder` の削除はビューに影響なし（`.json.jbuilder` ファイルが存在しない）
- [x] `ImageType` から削除したフィールド（`row_order`, `is_published`）はコンポーネントで参照されていない
- [x] `imageApi.test.ts` の既存テストは `limit` オプションを使用していないため影響なし
- [x] `images_spec.rb` は `row_order`/`is_published` をレスポンスアサートしていないため影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMfRtFB3AB97GfrgbChYVC)_