### PR TITLE
fix: loadMore中のカテゴリ変更によるレースコンディションを修正

### DIFF
--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -36,7 +36,7 @@ export default function GalleryApp({
 
   const hasPrevious = focusedImageIndex !== null && focusedImageIndex > 0;
   const hasNext = focusedImageIndex !== null && focusedImageIndex < images.length - 1;
-  const isInteractionDisabled = isLoadingImages;
+  const isInteractionDisabled = isLoadingImages || isLoadingMore;
 
   const isInteractionDisabledRef = useRef(isInteractionDisabled);
   const imagesLengthRef = useRef(images.length);


### PR DESCRIPTION
## 概要

コード品質チェック（2026-06-26）で発見したバグの修正です。

### 問題

`GalleryApp.tsx` の `isInteractionDisabled` が `isLoadingMore` を考慮していなかったため、追加ページ読み込み中（`loadMore` 実行中）にカテゴリフィルターを変更できる状態になっていました。

**レースコンディションの再現シナリオ:**
1. ユーザーがギャラリーを下スクロールし、IntersectionObserver が `loadMore` を発火
2. `loadMore` のフェッチ完了前に、ユーザーがカテゴリフィルターをクリック（`isLoadingImages` が false のため操作可能）
3. カテゴリ変更の `useEffect` が新しいフィルター済み画像を読み込み開始
4. `loadMore` が完了し、古いページのデータを `setImages((prev) => [...prev, ...result.images])` で追記
5. タイミングによっては古い画像データが新フィルター結果に混入する

### 修正内容

`isInteractionDisabled` に `isLoadingMore` を追加し、追加ページロード中はカテゴリ切り替えを無効化します。

```diff
- const isInteractionDisabled = isLoadingImages;
+ const isInteractionDisabled = isLoadingImages || isLoadingMore;
```

---

## 今回のコード品質チェック全体サマリー

| 種別 | 内容 | 対応 |
|---|---|---|
| 🔴 機能バグ | GalleryApp: loadMore 中カテゴリ変更でレースコンディション | **本PRで修正** |
| 🟡 軽微 | error.tsx / global-error.tsx: `console.error` のみでエラー追跡なし | 個人ポートフォリオとして許容範囲 |
| 🟡 軽微 | SiteHeader.tsx / MobileMenu.tsx: ESLintサプレスコメント2件 | 理由が明記されており問題なし |
| 🟢 極軽微 | ImageModal.tsx: aria-label が英語（UI は日本語） | 機能上問題なし |

全体として、コードの品質は高く、型安全性・エラーハンドリング・セキュリティ（secrets漏洩なし、SQLインジェクション対策済み）・パフォーマンス（メモ化・IntersectionObserver・RAF throttle）は良好です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6Py8pgKFqfRVA3C7xNm8i)_