### PR TITLE
fix(admin): 画像一覧のサムネ表示を 100px→64px に縮小

### DIFF
--- a/backend/app/views/admin/images/_image_row.html.haml
+++ b/backend/app/views/admin/images/_image_row.html.haml
@@ -4,7 +4,7 @@
     %span.order-number= (image.row_order_rank || 0) + 1
   %td
     - if image.file.attached?
-      = image_tag(image.thumbnail_variant, alt: "#{image.title} preview", style: "height: 100px; width: auto;")
+      = image_tag(image.thumbnail_variant, alt: "#{image.title} preview", style: "height: 64px; width: auto;")
     - else
       %span.text-muted プレビューなし
   %td= image.title


### PR DESCRIPTION
## 概要
admin 画像一覧のサムネイル表示が大きすぎたため、インライン style の height を 100px→64px に縮小。

Closes #225

## レビュー優先度
🟢 レビュー不要 — インライン style の px 値1行のみ。ロジック・データ・セキュリティへの影響なし

## 確認
- 変更箇所は `_image_row.html.haml` の `image_tag` の height 値のみ（`thumbnail_variant` 利用は元から）
- 実描画での目視確認は未実施（px 値変更のみのため低リスク。レビュー時に admin 一覧で確認可）