### PR TITLE
fix: コード品質改善 (APIフィールド制限・Admin表示順・開発環境URL修正)

### DIFF
--- a/backend/app/controllers/admin/cameras_controller.rb
+++ b/backend/app/controllers/admin/cameras_controller.rb
@@ -2,7 +2,7 @@ class Admin::CamerasController < Admin::Base
   before_action :set_camera, only: %i[show edit update destroy]
 
   def index
-    @cameras = Camera.all
+    @cameras = Camera.order(:manufacturer, :name)
   end
 
   def show; end

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -79,9 +79,9 @@ class Admin::ImagesController < Admin::Base
   private
 
   def set_cameras_and_lenses_and_categories
-    @cameras = Camera.all
-    @lenses = Lens.all
-    @categories = Category.all
+    @cameras = Camera.order(:manufacturer, :name)
+    @lenses = Lens.order(:name)
+    @categories = Category.order(:name)
   end
 
   def set_image

--- a/backend/app/controllers/admin/lenses_controller.rb
+++ b/backend/app/controllers/admin/lenses_controller.rb
@@ -2,7 +2,7 @@ class Admin::LensesController < Admin::Base
   before_action :set_lens, only: %i[edit update destroy]
 
   def index
-    @lenses = Lens.all
+    @lenses = Lens.order(:name)
   end
 
   def new

--- a/backend/app/controllers/api/categories_controller.rb
+++ b/backend/app/controllers/api/categories_controller.rb
@@ -1,6 +1,6 @@
 class Api::CategoriesController < ApplicationController
   def index
     categories = Category.order(:name)
-    render json: categories.map(&:as_json)
+    render json: categories.map { |c| c.as_json(only: %i[id name]) }
   end
 end

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -92,7 +92,7 @@ module CdnAttachedFile
   end
 
   def active_storage_url_for(attachable)
-    return nil unless Rails.env.test?
+    return nil unless Rails.env.test? || Rails.env.development?
 
     helpers = Rails.application.routes.url_helpers
     host = ENV.fetch("ACTIVE_STORAGE_HOST", "http://localhost:3000")

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -92,7 +92,7 @@ module CdnAttachedFile
   end
 
   def active_storage_url_for(attachable)
-    return nil unless Rails.env.test? || Rails.env.development?
+    return nil unless Rails.env.local?
 
     helpers = Rails.application.routes.url_helpers
     host = ENV.fetch("ACTIVE_STORAGE_HOST", "http://localhost:3000")


### PR DESCRIPTION
## 概要

定期的なコード品質チェックで発見した3点の問題を修正します。

## 変更内容

### 1. `Api::CategoriesController` — 不要なフィールドの公開を制限

`categories.map(&:as_json)` は `created_at` / `updated_at` を含む全フィールドを返していました。フロントエンドが必要とするのは `id` と `name` のみなので、`only: [:id, :name]` を追加してデータ最小化の原則に沿った実装に修正します。

### 2. Admin Camera / Lens / Category 一覧・ドロップダウンの順序を安定化

以下の箇所で `.all` を使っていたため、レコードの表示順が挿入順に依存していました：

- `Admin::CamerasController#index` → `order(:manufacturer, :name)` に変更
- `Admin::LensesController#index` → `order(:name)` に変更
- `Admin::ImagesController#set_cameras_and_lenses_and_categories` （画像登録・編集フォームのドロップダウン） → 各モデルに `order` 句を追加

これにより、管理画面で常に安定したアルファベット順で表示されるようになります。

### 3. `CdnAttachedFile#active_storage_url_for` を開発環境でも有効化

`return nil unless Rails.env.test?` という条件が原因で、CDN（`CLOUDFRONT_BASE_URL`）が未設定の開発環境では画像URLが常に `nil` を返していました。`development?` を条件に追加することで、ローカル開発環境でも ActiveStorage の blob URL が生成されるようになります。

## 影響範囲

- バックエンドのみ、フロントエンドの変更なし
- DB マイグレーション不要
- 既存のテストへの影響なし（`test` 環境の挙動は変わらない）

## 検出されたが今回対応しない問題

- `articles` / `publishments` テーブルが schema.rb に残存（対応するモデルなし）— DB マイグレーションを伴うため別 issue として管理推奨


---
_Generated by [Claude Code](https://claude.ai/code/session_01UcyoPr4dq4niGSExHewdL1)_