### PR TITLE
fix: コード品質修正（カテゴリ部分更新バグ・バリデーション・日本語統一）

### DIFF
--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -33,11 +33,7 @@ class Image < ApplicationRecord
   before_validation :fill_metadata_from_exif, on: :create
 
   def category_ids=(ids)
-    super
-    # 保存後にカテゴリーの関連付けを更新
-    return unless persisted?
-
-    self.categories = Category.where(id: ids.compact_blank)
+    super(Array(ids).compact_blank)
   end
 
   def publishable?
@@ -86,6 +82,6 @@ class Image < ApplicationRecord
   def taken_at_is_in_the_past
     return if taken_at.nil?
 
-    errors.add(:taken_at, 'must be in the past') if taken_at > Time.zone.now
+    errors.add(:taken_at, 'must be in the past') if taken_at > 1.minute.from_now
   end
 end


### PR DESCRIPTION
## 概要

コード品質チェック（2026-07-01）で発見した3件の問題を修正します。

## 修正内容

### 1. バグ修正: `image.rb` — カテゴリ部分更新バグ（Medium）

**問題:**  
`category_ids=` のオーバーライドが、レコード更新時にトランザクション外で即座に `self.categories = ...` を呼び出していました。その後 `save` でバリデーションエラーが発生した場合、カテゴリだけが更新済みになる部分更新状態が生じていました。

**修正:**  
`compact_blank` 済みの ids を `super` に渡すだけに変更し、Rails 標準の `save` トランザクション内で一貫した更新を行うようにしました。

```ruby
# before
def category_ids=(ids)
  super
  return unless persisted?
  self.categories = Category.where(id: ids.compact_blank)
end

# after
def category_ids=(ids)
  super(Array(ids).compact_blank)
end
```

### 2. バリデーション改善: `image.rb` — `taken_at_is_in_the_past` の比較に余裕を追加（Low）

**問題:**  
`taken_at > Time.zone.now` と厳密比較していたため、サーバー時刻のわずかなずれ（クロックドリフト）で「現在時刻とほぼ同時刻に撮影した写真」が誤ってバリデーションエラーになる可能性がありました。

**修正:**  
`1.minute.from_now` に変更し、微小な時刻差を許容するようにしました。

### 3. I18n修正: `ImageModal.tsx` — エラーメッセージを日本語に統一（Low）

**問題:**  
画像読み込み失敗時のエラー文が `"Failed to load image"` と英語のままで、他のUIの日本語表示と不整合でした。

**修正:**  
`"画像を読み込めませんでした"` に変更しました。

## 影響範囲

- `backend/app/models/image.rb` — カテゴリ更新ロジック、taken_at バリデーション
- `frontend/src/app/gallery/_components/ImageModal.tsx` — エラーメッセージ表示


---
_Generated by [Claude Code](https://claude.ai/code/session_01TCPQoXVq24H5VtThBBcVBF)_