### PR TITLE
chore(deps): dependabot で eslint の major update を ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # eslint-config-next が eslint 10 対応を出すまで major を止める (#177)
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## 概要
#177 で決定済みだった「eslint-config-next が eslint 10 対応を出すまで eslint の major bump を ignore する」設定が dependabot.yml に未反映だったので反映する。

Closes #177

## レビュー優先度
🟢 レビュー不要 — 決定済み事項(#177)の宣言的設定4行のみ

## 確認
YAML 構文は dependabot v2 の `ignore` / `update-types` 仕様どおり。実際の抑止は次回の dependabot 実行で確認（eslint 10 の PR が新規作成されないこと）。#73 は blocked トラッカーとして残す。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)