### PR TITLE
feat(admin): 画像の一括取り込み + 逐次キュレーションのワークフロー

### DIFF
--- a/backend/app/controllers/admin/image_bulk_imports_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_imports_controller.rb
@@ -1,0 +1,42 @@
+class Admin::ImageBulkImportsController < Admin::Base
+  def new
+    @categories = Category.order(:name)
+    @results = nil
+  end
+
+  # Ingests each direct-uploaded blob as a draft Image (EXIF metadata is filled
+  # by the model layer). Failures are isolated per file so one bad frame never
+  # aborts the rest of the roll; the result list says exactly which files failed.
+  def create
+    @categories = Category.order(:name)
+    signed_ids = Array(params.dig(:bulk, :files)).compact_blank
+    category_ids = Array(params.dig(:bulk, :category_ids)).compact_blank
+
+    if signed_ids.empty?
+      flash.now[:alert] = 'ファイルが選択されていません。'
+      return render :new, status: :unprocessable_content
+    end
+
+    @results = signed_ids.map { |signed_id| ingest_draft(signed_id, category_ids) }
+    failed = @results.count { |result| result[:image].nil? || !result[:image].persisted? }
+
+    if failed.zero?
+      redirect_to admin_images_path(filter: "uncurated"),
+                  notice: "#{@results.size}枚を下書きとして取り込みました。1枚ずつタイトルを付けて公開してください。"
+    else
+      flash.now[:alert] = "#{failed}枚の取り込みに失敗しました（#{@results.size - failed}枚は成功）。"
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def ingest_draft(signed_id, category_ids)
+    blob = ActiveStorage::Blob.find_signed!(signed_id)
+    image = Image.new(file: signed_id, is_published: false, category_ids: category_ids)
+    image.save
+    { filename: blob.filename.to_s, image: image, errors: image.errors.full_messages }
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+    { filename: signed_id.to_s.truncate(24), image: nil, errors: ['アップロードが無効です（再アップロードしてください）'] }
+  end
+end

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -4,6 +4,8 @@ class Admin::ImagesController < Admin::Base
 
   def index
     @images = Image.rank(:row_order).with_attached_file
+    @uncurated_count = Image.uncurated.count
+    @images = @images.uncurated if params[:filter] == "uncurated"
   end
 
   def show; end
@@ -31,6 +33,8 @@ class Admin::ImagesController < Admin::Base
     apply_row_order_position(@image)
 
     if @image.save
+      return redirect_to_next_uncurated if params[:save_and_next].present?
+
       redirect_to admin_images_path(@image, format: nil), notice: 'Image was successfully updated.'
     else
       flash.now[:alert] = 'Image failed to update.'
@@ -86,6 +90,16 @@ class Admin::ImagesController < Admin::Base
 
   def set_image
     @image = Image.find(params[:id])
+  end
+
+  def redirect_to_next_uncurated
+    next_image = Image.uncurated.where.not(id: @image.id).rank(:row_order).first
+    if next_image
+      remaining = Image.uncurated.where.not(id: @image.id).count
+      redirect_to edit_admin_image_path(next_image), notice: "保存しました。残り#{remaining}枚の下書きがあります。"
+    else
+      redirect_to admin_images_path, notice: '保存しました。未編集の下書きはありません。'
+    end
   end
 
   def apply_row_order_position(image)

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -3,7 +3,7 @@ class Admin::ImagesController < Admin::Base
 
   before_action :set_cameras_and_lenses_and_categories, only: %i[new edit create update]
   before_action :set_image, only: %i[show edit update destroy insert_at toggle_publish]
-  before_action :set_next_draft_flag, only: %i[edit update]
+  before_action :set_adjacent_images, only: %i[edit update]
 
   def index
     @images = Image.rank(:row_order).with_attached_file
@@ -25,7 +25,7 @@ class Admin::ImagesController < Admin::Base
     apply_row_order_position(@image)
 
     if @image.save
-      redirect_to admin_images_path(@image, format: nil), notice: 'Image was successfully created.'
+      redirect_to admin_images_path, notice: update_notice
     else
       flash.now[:alert] = 'Image failed to create.'
       render :new, status: :unprocessable_content
@@ -39,9 +39,7 @@ class Admin::ImagesController < Admin::Base
     apply_row_order_position(@image)
 
     if @image.save
-      return redirect_to_next_uncurated if advance_to_next?
-
-      redirect_to admin_images_path(@image, format: nil), notice: 'Image was successfully updated.'
+      redirect_to after_save_edit_path, notice: update_notice
     else
       # 公開しようとして弾かれた場合もフォームは元の公開状態のまま再描画する
       @image.restore_attributes(%i[is_published])

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ImagesController < Admin::Base
   before_action :set_cameras_and_lenses_and_categories, only: %i[new edit create update]
-  before_action :set_image, only: %i[show edit update destroy insert_at]
+  before_action :set_image, only: %i[show edit update destroy insert_at toggle_publish]
 
   def index
     @images = Image.rank(:row_order).with_attached_file
@@ -51,9 +51,20 @@ class Admin::ImagesController < Admin::Base
     end
   end
 
+  # Index の行から公開/非公開をワンクリックで切り替える。公開条件
+  # （title/taken_at）を欠く下書きはバリデーションで弾かれ flash に出る。
+  def toggle_publish
+    @image.is_published = !@image.is_published
+    if @image.save
+      status = @image.is_published? ? '公開しました' : '非公開にしました'
+      redirect_back_or_to(admin_images_path, notice: "「#{@image.title}」を#{status}。")
+    else
+      redirect_back_or_to(admin_images_path, alert: "公開できません: #{@image.errors.full_messages.join('、')}")
+    end
+  end
+
   def insert_at
-    position = insert_params.to_i
-    @image.row_order_position = position
+    @image.row_order_position = insert_params.to_i
     if @image.save
       head :ok
     else
@@ -93,13 +104,11 @@ class Admin::ImagesController < Admin::Base
   end
 
   def redirect_to_next_uncurated
-    next_image = Image.uncurated.where.not(id: @image.id).rank(:row_order).first
-    if next_image
-      remaining = Image.uncurated.where.not(id: @image.id).count
-      redirect_to edit_admin_image_path(next_image), notice: "保存しました。残り#{remaining}枚の下書きがあります。"
-    else
-      redirect_to admin_images_path, notice: '保存しました。未編集の下書きはありません。'
-    end
+    remaining = Image.uncurated.where.not(id: @image.id)
+    next_image = remaining.rank(:row_order).first
+    return redirect_to admin_images_path, notice: '保存しました。未編集の下書きはありません。' if next_image.nil?
+
+    redirect_to edit_admin_image_path(next_image), notice: "保存しました。残り#{remaining.count}枚の下書きがあります。"
   end
 
   def apply_row_order_position(image)

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -1,6 +1,9 @@
 class Admin::ImagesController < Admin::Base
+  include Admin::ImageCurationFlow
+
   before_action :set_cameras_and_lenses_and_categories, only: %i[new edit create update]
   before_action :set_image, only: %i[show edit update destroy insert_at toggle_publish]
+  before_action :set_next_draft_flag, only: %i[edit update]
 
   def index
     @images = Image.rank(:row_order).with_attached_file
@@ -18,6 +21,7 @@ class Admin::ImagesController < Admin::Base
 
   def create
     @image = Image.new(image_params.except(:row_order_position))
+    @image.is_published = publish_intent || false
     apply_row_order_position(@image)
 
     if @image.save
@@ -30,15 +34,18 @@ class Admin::ImagesController < Admin::Base
 
   def update
     @image.assign_attributes(image_params.except(:row_order_position))
+    intent = publish_intent
+    @image.is_published = intent unless intent.nil?
     apply_row_order_position(@image)
 
     if @image.save
-      return redirect_to_next_uncurated if params[:save_and_next].present?
+      return redirect_to_next_uncurated if advance_to_next?
 
       redirect_to admin_images_path(@image, format: nil), notice: 'Image was successfully updated.'
     else
+      # 公開しようとして弾かれた場合もフォームは元の公開状態のまま再描画する
+      @image.restore_attributes(%i[is_published])
       flash.now[:alert] = 'Image failed to update.'
-      Rails.logger.debug { "Image failed to update: #{@image.errors.full_messages.join(', ')}" }
       render :edit, status: :unprocessable_content
     end
   end
@@ -51,15 +58,18 @@ class Admin::ImagesController < Admin::Base
     end
   end
 
-  # Index の行から公開/非公開をワンクリックで切り替える。公開条件
-  # （title/taken_at）を欠く下書きはバリデーションで弾かれ flash に出る。
+  # Index の行から公開/非公開をワンクリックで切り替える。公開条件を満たさない
+  # 下書きにはボタン自体を出さないが、直リンク等で来た場合は編集画面へ誘導する。
   def toggle_publish
-    @image.is_published = !@image.is_published
-    if @image.save
+    if !@image.is_published? && !@image.publishable?
+      return redirect_to edit_admin_image_path(@image), alert: '公開にはタイトルと撮影日時が必要です。'
+    end
+
+    if @image.update(is_published: !@image.is_published)
       status = @image.is_published? ? '公開しました' : '非公開にしました'
       redirect_back_or_to(admin_images_path, notice: "「#{@image.title}」を#{status}。")
     else
-      redirect_back_or_to(admin_images_path, alert: "公開できません: #{@image.errors.full_messages.join('、')}")
+      redirect_back_or_to(admin_images_path, alert: "更新できません: #{@image.errors.full_messages.join('、')}")
     end
   end
 
@@ -103,14 +113,6 @@ class Admin::ImagesController < Admin::Base
     @image = Image.find(params[:id])
   end
 
-  def redirect_to_next_uncurated
-    remaining = Image.uncurated.where.not(id: @image.id)
-    next_image = remaining.rank(:row_order).first
-    return redirect_to admin_images_path, notice: '保存しました。未編集の下書きはありません。' if next_image.nil?
-
-    redirect_to edit_admin_image_path(next_image), notice: "保存しました。残り#{remaining.count}枚の下書きがあります。"
-  end
-
   def apply_row_order_position(image)
     image.row_order_position = image_params[:row_order_position].to_i if image_params[:row_order_position].present?
   end
@@ -118,7 +120,7 @@ class Admin::ImagesController < Admin::Base
   def image_params
     params.expect(
       image: [:title, :caption, :taken_at, :camera_id, :lens_id,
-              :row_order_position, :is_published, :file,
+              :row_order_position, :file,
               { category_ids: [] }]
     )
   end

--- a/backend/app/controllers/concerns/admin/image_curation_flow.rb
+++ b/backend/app/controllers/concerns/admin/image_curation_flow.rb
@@ -1,0 +1,34 @@
+# 一括取り込み後の逐次キュレーション（下書きを順に編集して公開していく）フローと、
+# フォームの送信ボタン（下書き保存/公開/次へ）からの公開状態の導出。
+module Admin::ImageCurationFlow
+  extend ActiveSupport::Concern
+
+  private
+
+  # 押されたボタンから公開状態を導出する。
+  # true = 公開 / false = 下書き / nil = 変更なし（公開中の画像の「保存」）
+  def publish_intent
+    return true if params[:commit_publish].present? || params[:publish_and_next].present?
+    return false if params[:commit_draft].present?
+
+    nil
+  end
+
+  def advance_to_next?
+    params[:save_and_next].present? || params[:publish_and_next].present?
+  end
+
+  # 「次へ」ボタンの表示可否（編集中の画像以外に未編集の下書きが残っているか）
+  def set_next_draft_flag
+    @next_draft_exists = Image.uncurated.where.not(id: @image.id).exists?
+  end
+
+  def redirect_to_next_uncurated
+    verb = @image.is_published? ? '公開しました' : '保存しました'
+    remaining = Image.uncurated.where.not(id: @image.id)
+    next_image = remaining.rank(:row_order).first
+    return redirect_to admin_images_path, notice: "#{verb}。未編集の下書きはありません。" if next_image.nil?
+
+    redirect_to edit_admin_image_path(next_image), notice: "#{verb}。残り#{remaining.count}枚の下書きがあります。"
+  end
+end

--- a/backend/app/controllers/concerns/admin/image_curation_flow.rb
+++ b/backend/app/controllers/concerns/admin/image_curation_flow.rb
@@ -1,34 +1,40 @@
-# 一括取り込み後の逐次キュレーション（下書きを順に編集して公開していく）フローと、
-# フォームの送信ボタン（下書き保存/公開/次へ）からの公開状態の導出。
+# 画像編集カードのフロー。送信ボタン（保存 / 公開する / 非公開に戻す / ← →）から
+# 公開状態と保存後の遷移先を導出する。←/→ は保存してから隣のカードへ移動する。
 module Admin::ImageCurationFlow
   extend ActiveSupport::Concern
 
   private
 
   # 押されたボタンから公開状態を導出する。
-  # true = 公開 / false = 下書き / nil = 変更なし（公開中の画像の「保存」）
+  # true = 公開 / false = 下書きへ戻す / nil = 変更なし
   def publish_intent
-    return true if params[:commit_publish].present? || params[:publish_and_next].present?
+    return true if params[:commit_publish].present?
     return false if params[:commit_draft].present?
 
     nil
   end
 
-  def advance_to_next?
-    params[:save_and_next].present? || params[:publish_and_next].present?
+  # 表示順で隣り合う画像（編集カードの ←/→ の行き先と disabled 判定）
+  def set_adjacent_images
+    @images_total = Image.count
+    @prev_image = Image.rank(:row_order).where(row_order: ...@image.row_order).last
+    @next_image = Image.rank(:row_order).where(row_order: (@image.row_order + 1)..).first
   end
 
-  # 「次へ」ボタンの表示可否（編集中の画像以外に未編集の下書きが残っているか）
-  def set_next_draft_flag
-    @next_draft_exists = Image.uncurated.where.not(id: @image.id).exists?
+  def after_save_edit_path
+    target = if params[:nav_prev].present?
+               @prev_image
+             elsif params[:nav_next].present?
+               @next_image
+             end
+    edit_admin_image_path(target || @image)
   end
 
-  def redirect_to_next_uncurated
-    verb = @image.is_published? ? '公開しました' : '保存しました'
-    remaining = Image.uncurated.where.not(id: @image.id)
-    next_image = remaining.rank(:row_order).first
-    return redirect_to admin_images_path, notice: "#{verb}。未編集の下書きはありません。" if next_image.nil?
-
-    redirect_to edit_admin_image_path(next_image), notice: "#{verb}。残り#{remaining.count}枚の下書きがあります。"
+  def update_notice
+    case publish_intent
+    when true then '公開しました。'
+    when false then '非公開にしました。'
+    else '保存しました。'
+    end
   end
 end

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -13,11 +13,14 @@ class Image < ApplicationRecord
 
   has_one_attached :file, dependent: :purge_later
 
+  # 公開に必要な項目の単一ソース。バリデーションと publishable?
+  # （UI で公開ボタンを出すかの判定）を両方ここから導出する。
+  PUBLISH_REQUIREMENTS = %i[title taken_at].freeze
+
   validates :file, presence: true
   # Records exist as drafts first (bulk ingest); title/taken_at are
   # publish-quality requirements, not record-existence requirements.
-  validates :title, presence: true, if: :is_published?
-  validates :taken_at, presence: true, if: :is_published?
+  PUBLISH_REQUIREMENTS.each { |attr| validates attr, presence: true, if: :is_published? }
   validates :is_published, inclusion: { in: [true, false] }
 
   scope :published, -> { where(is_published: true) }
@@ -35,6 +38,10 @@ class Image < ApplicationRecord
     return unless persisted?
 
     self.categories = Category.where(id: ids.compact_blank)
+  end
+
+  def publishable?
+    PUBLISH_REQUIREMENTS.all? { |attr| public_send(attr).present? }
   end
 
   def self.filter_by_categories(category_ids)

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -14,15 +14,20 @@ class Image < ApplicationRecord
   has_one_attached :file, dependent: :purge_later
 
   validates :file, presence: true
-  validates :title, presence: true
-  validates :caption, presence: true
-  validates :taken_at, presence: true
+  # Records exist as drafts first (bulk ingest); title/taken_at are
+  # publish-quality requirements, not record-existence requirements.
+  validates :title, presence: true, if: :is_published?
+  validates :taken_at, presence: true, if: :is_published?
   validates :is_published, inclusion: { in: [true, false] }
 
   scope :published, -> { where(is_published: true) }
+  scope :draft, -> { where(is_published: false) }
+  scope :uncurated, -> { draft.where(title: [nil, ""]) }
   scope :ordered_for_gallery, -> { order(row_order: :asc, id: :asc) }
 
   validate :taken_at_is_in_the_past
+
+  before_validation :fill_metadata_from_exif, on: :create
 
   def category_ids=(ids)
     super
@@ -56,6 +61,20 @@ class Image < ApplicationRecord
   end
 
   private
+
+  # Fills taken_at/camera/lens from the attached file's EXIF so every creation
+  # path (admin form, bulk ingest, rake, API) gets metadata without client JS.
+  # Only fills blanks — human input always wins — and only runs when the blob
+  # is already in storage (direct upload / io attach). Fail-open via ExifExtractor.
+  def fill_metadata_from_exif
+    return unless file.attached? && file.blob&.persisted?
+    return if taken_at.present? && camera_id.present? && lens_id.present?
+
+    exif = ExifExtractor.from_blob(file.blob)
+    self.taken_at ||= exif.taken_at
+    self.camera ||= Camera.resolve_from_exif(make: exif.make, model: exif.model)
+    self.lens ||= Lens.resolve_from_exif(exif.lens_model)
+  end
 
   def taken_at_is_in_the_past
     return if taken_at.nil?

--- a/backend/app/views/admin/cameras/index.html.haml
+++ b/backend/app/views/admin/cameras/index.html.haml
@@ -1,8 +1,5 @@
 %h1 カメラ一覧
 
-- if flash.notice
-  .alert.alert-info= flash[:notice]
-
 .table-responsive
   %table.table.table-striped
     %thead

--- a/backend/app/views/admin/categories/index.html.haml
+++ b/backend/app/views/admin/categories/index.html.haml
@@ -1,8 +1,5 @@
 %h1 カテゴリー一覧
 
-- if flash.notice
-  .alert.alert-info= flash[:notice]
-
 .table-responsive
   %table.table.table-striped
     %thead

--- a/backend/app/views/admin/image_bulk_imports/new.html.haml
+++ b/backend/app/views/admin/image_bulk_imports/new.html.haml
@@ -1,0 +1,36 @@
+%h1 画像の一括取り込み
+
+%p.text-muted
+  選択したファイルはすべて「下書き」として保存されます。taken_at / カメラ / レンズは EXIF から自動で入ります。
+  タイトルは取り込み後に1枚ずつ編集してください。
+
+- if flash.now[:alert]
+  .alert.alert-danger= flash.now[:alert]
+
+- if @results.present?
+  %ul.list-group.mb-3
+    - @results.each do |result|
+      - if result[:image]&.persisted?
+        %li.list-group-item.list-group-item-success ✓ #{result[:filename]} — 下書きとして作成しました
+      - else
+        %li.list-group-item.list-group-item-danger ✗ #{result[:filename]} — #{result[:errors].join('、')}
+
+= form_with(url: admin_image_bulk_import_path, scope: :bulk, local: true, multipart: true, data: { controller: "direct-upload" }, style: "border: 2px dashed #ccc; padding: 20px; border-radius: 8px;") do |form|
+  .mb-3
+    = form.label :files, '画像ファイル（複数選択可）', class: 'col-form-label fw-bold'
+    = form.file_field :files, multiple: true, direct_upload: true, accept: 'image/*', class: 'form-control', data: { direct_upload_target: "input" }
+  .progress.d-none.mb-3{ data: { direct_upload_target: "progress" } }
+    .progress-bar.progress-bar-striped.progress-bar-animated{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100", style: "width: 0%" }
+  .alert.alert-danger.d-none.mb-3{ data: { direct_upload_target: "error" } }
+
+  %h3 共通カテゴリ（全画像に適用）
+  - @categories.each do |category|
+    .form-check
+      = check_box_tag 'bulk[category_ids][]', category.id, false, id: "bulk_category_#{category.id}", class: 'form-check-input'
+      = label_tag "bulk_category_#{category.id}", category.name, class: 'form-check-label'
+
+  .row.mt-3
+    .col
+      = form.submit '下書きとして取り込む', class: 'btn btn-primary d-block w-100'
+
+= link_to '画像一覧に戻る', admin_images_path, class: 'btn btn-link mt-3'

--- a/backend/app/views/admin/image_bulk_imports/new.html.haml
+++ b/backend/app/views/admin/image_bulk_imports/new.html.haml
@@ -4,9 +4,6 @@
   選択したファイルはすべて「下書き」として保存されます。taken_at / カメラ / レンズは EXIF から自動で入ります。
   タイトルは取り込み後に1枚ずつ編集してください。
 
-- if flash.now[:alert]
-  .alert.alert-danger= flash.now[:alert]
-
 - if @results.present?
   %ul.list-group.mb-3
     - @results.each do |result|

--- a/backend/app/views/admin/images/_form.html.haml
+++ b/backend/app/views/admin/images/_form.html.haml
@@ -53,17 +53,28 @@
       = form.check_box :category_ids, { multiple: true, checked: image.categories.include?(category), id: "category_#{category.id}" }, category.id, nil
       = form.label "category_#{category.id}", category.name, class: "form-check-label"
 
-  .row.mb-3
-    .col-md-3
-      = form.label :is_published, 'Publish Settings', class: 'col-form-label fw-bold'
-    .col-md-9
-      .form-check
-        = form.check_box :is_published, class: 'form-check-input'
-        = form.label :is_published, 'Publish', class: 'form-check-label'
-  .row
-    .col
-      = form.submit 'Save', class: 'btn btn-primary d-block w-100'
-  - if image.persisted? && !image.is_published
-    .row.mt-2
+  - if image.persisted?
+    .row.mb-3
+      .col-md-3
+        %span.col-form-label.fw-bold 公開状態
+      .col-md-9= render 'admin/images/status_badge', image: image
+
+  - if image.is_published?
+    .row
       .col
-        = form.submit 'Save & Next（次の下書きへ）', name: 'save_and_next', class: 'btn btn-outline-primary d-block w-100'
+        .d-flex.gap-2
+          = form.submit '保存', class: 'btn btn-primary flex-fill'
+          = form.submit '非公開にして保存', name: 'commit_draft', class: 'btn btn-outline-secondary flex-fill'
+  - else
+    .row
+      .col
+        .d-flex.gap-2
+          = form.submit '下書きとして保存', name: 'commit_draft', class: 'btn btn-outline-secondary flex-fill'
+          = form.submit '公開して保存', name: 'commit_publish', class: 'btn btn-primary flex-fill'
+        %small.text-muted.d-block.mt-1 公開にはタイトルと撮影日時が必要です
+    - if image.persisted? && local_assigns.fetch(:next_draft_exists, false)
+      .row.mt-2
+        .col
+          .d-flex.gap-2
+            = form.submit '下書きのまま次へ', name: 'save_and_next', class: 'btn btn-outline-primary flex-fill'
+            = form.submit '公開して次へ', name: 'publish_and_next', class: 'btn btn-outline-success flex-fill'

--- a/backend/app/views/admin/images/_form.html.haml
+++ b/backend/app/views/admin/images/_form.html.haml
@@ -1,80 +1,72 @@
-= form_with(model: image, url: image.new_record? ? admin_images_path : admin_image_path(image), local: true, multipart: true, data: { controller: "exif-fill direct-upload" }, style: "border: 2px dashed #ccc; padding: 20px; border-radius: 8px;") do |form|
+= form_with(model: image, url: image.new_record? ? admin_images_path : admin_image_path(image), local: true, multipart: true, data: { controller: "exif-fill direct-upload" }) do |form|
   - if image.errors.any?
     .alert.alert-danger
-      %ul
+      %ul.mb-0
         - image.errors.full_messages.each do |message|
           %li= message
-  - unless image.file.attached?
-    .row.mb-3
-      .col-md-3
-        = form.label :file, 'Image File', class: 'col-form-label fw-bold'
-      .col-md-9
-        = form.file_field :file, direct_upload: true, class: 'form-control', data: { direct_upload_target: "input", exif_fill_target: "fileInput", action: "change->exif-fill#fileSelected" }
-        %div{ data: { exif_fill_target: 'status' } }
-    .row.mb-3
-      .col-md-9.offset-md-3
-        .progress.d-none{ data: { direct_upload_target: "progress" } }
-          .progress-bar.progress-bar-striped.progress-bar-animated{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100", style: "width: 0%" }
-        .alert.alert-danger.d-none.mt-2{ data: { direct_upload_target: "error" } }
-  .row.mb-3
-    .col-md-3
-      = form.label :title, 'Title', class: 'col-form-label fw-bold'
-    .col-md-9= form.text_field :title, class: 'form-control', data: { exif_fill_target: "titleInput" }
-  .row.mb-3
-    .col-md-3
-      = form.label :caption, 'Caption', class: 'col-form-label fw-bold'
-    .col-md-9= form.text_area :caption, class: 'form-control'
-  .row.mb-3
-    .col-md-3
-      = form.label :taken_at, 'Taken At', class: 'col-form-label fw-bold'
-    .col-md-9= form.datetime_field :taken_at, class: 'form-control', data: { exif_fill_target: "takenAtInput" }
-  .row.mb-3
-    .col-md-3
-      = form.label :camera_id, 'Camera', class: 'col-form-label fw-bold'
-    .col-md-9= form.collection_select :camera_id, cameras, :id, :name, { include_blank: "Please select" }, class: 'form-control', data: { exif_fill_target: "cameraSelect" }
-  .row.mb-3
-    .col-md-3
-      = form.label :lens_id, 'Lens', class: 'col-form-label fw-bold'
-    .col-md-9= form.collection_select :lens_id, lenses, :id, :name, { include_blank: "Please select" }, class: 'form-control', data: { exif_fill_target: "lensSelect" }
-  .row.mb-3
-    .col-md-3
-      = form.label :row_order_position, 'Display Order', class: 'col-form-label fw-bold'
-    .col-md-9
-      = form.number_field :row_order_position, class: 'form-control', value: (image.persisted? ? (image.row_order_rank || 0) : nil)
-      %small.text-muted.d-block.mt-1
-        - if image.persisted?
-          = "現在の順序: #{(image.row_order_rank || 0) + 1}番目（0始まりで入力）"
+
+  .card
+    .row.g-0
+      .col-lg-6.d-flex.align-items-center.justify-content-center.bg-body-tertiary.p-3{style: 'min-height: 320px;'}
+        - if image.file.attached?
+          = image_tag image.thumbnail_variant, class: 'img-fluid rounded', style: 'max-height: 70vh; object-fit: contain;', alt: image.title.presence || 'preview'
         - else
-          = "0始まりで入力してください（例: 0 = 最初、1 = 2番目）"
+          .w-100
+            = form.label :file, '画像ファイル', class: 'form-label fw-bold'
+            = form.file_field :file, direct_upload: true, class: 'form-control', data: { direct_upload_target: "input", exif_fill_target: "fileInput", action: "change->exif-fill#fileSelected" }
+            %div{ data: { exif_fill_target: 'status' } }
+            .progress.d-none.mt-2{ data: { direct_upload_target: "progress" } }
+              .progress-bar.progress-bar-striped.progress-bar-animated{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100", style: "width: 0%" }
+            .alert.alert-danger.d-none.mt-2{ data: { direct_upload_target: "error" } }
 
-  %h3 Categories
-  - categories.each do |category|
-    .form-check
-      = form.check_box :category_ids, { multiple: true, checked: image.categories.include?(category), id: "category_#{category.id}" }, category.id, nil
-      = form.label "category_#{category.id}", category.name, class: "form-check-label"
+      .col-lg-6.d-flex.flex-column
+        .card-body
+          - if image.persisted?
+            .d-flex.justify-content-between.align-items-center.mb-3
+              = render 'admin/images/status_badge', image: image
+              - if local_assigns[:images_total]
+                %small.text-muted= "#{(image.row_order_rank || 0) + 1} / #{local_assigns[:images_total]} 枚目"
+          .mb-3
+            = form.label :title, 'タイトル', class: 'form-label fw-bold'
+            = form.text_field :title, class: 'form-control', data: { exif_fill_target: "titleInput" }
+          .mb-3
+            = form.label :caption, 'キャプション', class: 'form-label fw-bold'
+            = form.text_area :caption, rows: 2, class: 'form-control'
+          .row
+            .col-md-6.mb-3
+              = form.label :taken_at, '撮影日時', class: 'form-label fw-bold'
+              = form.datetime_field :taken_at, class: 'form-control', data: { exif_fill_target: "takenAtInput" }
+            .col-md-6.mb-3
+              = form.label :row_order_position, '表示順（0始まり）', class: 'form-label fw-bold'
+              = form.number_field :row_order_position, class: 'form-control', value: (image.persisted? ? (image.row_order_rank || 0) : nil)
+          .row
+            .col-md-6.mb-3
+              = form.label :camera_id, 'カメラ', class: 'form-label fw-bold'
+              = form.collection_select :camera_id, cameras, :id, :name, { include_blank: "未選択" }, class: 'form-select', data: { exif_fill_target: "cameraSelect" }
+            .col-md-6.mb-3
+              = form.label :lens_id, 'レンズ', class: 'form-label fw-bold'
+              = form.collection_select :lens_id, lenses, :id, :name, { include_blank: "未選択" }, class: 'form-select', data: { exif_fill_target: "lensSelect" }
+          .mb-2
+            %span.form-label.fw-bold.d-block カテゴリ
+            - if categories.any?
+              - categories.each do |category|
+                .form-check.form-check-inline
+                  = form.check_box :category_ids, { multiple: true, checked: image.categories.include?(category), id: "category_#{category.id}" }, category.id, nil
+                  = form.label "category_#{category.id}", category.name, class: "form-check-label"
+            - else
+              %span.text-muted カテゴリが未登録です
 
-  - if image.persisted?
-    .row.mb-3
-      .col-md-3
-        %span.col-form-label.fw-bold 公開状態
-      .col-md-9= render 'admin/images/status_badge', image: image
-
-  - if image.is_published?
-    .row
-      .col
-        .d-flex.gap-2
-          = form.submit '保存', class: 'btn btn-primary flex-fill'
-          = form.submit '非公開にして保存', name: 'commit_draft', class: 'btn btn-outline-secondary flex-fill'
-  - else
-    .row
-      .col
-        .d-flex.gap-2
-          = form.submit '下書きとして保存', name: 'commit_draft', class: 'btn btn-outline-secondary flex-fill'
-          = form.submit '公開して保存', name: 'commit_publish', class: 'btn btn-primary flex-fill'
-        %small.text-muted.d-block.mt-1 公開にはタイトルと撮影日時が必要です
-    - if image.persisted? && local_assigns.fetch(:next_draft_exists, false)
-      .row.mt-2
-        .col
-          .d-flex.gap-2
-            = form.submit '下書きのまま次へ', name: 'save_and_next', class: 'btn btn-outline-primary flex-fill'
-            = form.submit '公開して次へ', name: 'publish_and_next', class: 'btn btn-outline-success flex-fill'
+        .card-footer.mt-auto
+          .d-flex.justify-content-between.align-items-center.gap-2
+            - if image.persisted?
+              = form.submit '← 前へ', name: 'nav_prev', class: 'btn btn-outline-secondary', disabled: local_assigns[:prev_image].nil?
+            .d-flex.gap-2.mx-auto
+              = form.submit '保存', class: 'btn btn-primary'
+              - if image.is_published?
+                = form.submit '非公開に戻す', name: 'commit_draft', class: 'btn btn-outline-secondary'
+              - else
+                = form.submit '公開する', name: 'commit_publish', class: 'btn btn-success'
+            - if image.persisted?
+              = form.submit '次へ →', name: 'nav_next', class: 'btn btn-outline-secondary', disabled: local_assigns[:next_image].nil?
+          - unless image.is_published?
+            %small.text-muted.d-block.text-center.mt-1 公開にはタイトルと撮影日時が必要です

--- a/backend/app/views/admin/images/_form.html.haml
+++ b/backend/app/views/admin/images/_form.html.haml
@@ -63,3 +63,7 @@
   .row
     .col
       = form.submit 'Save', class: 'btn btn-primary d-block w-100'
+  - if image.persisted? && !image.is_published
+    .row.mt-2
+      .col
+        = form.submit 'Save & Next（次の下書きへ）', name: 'save_and_next', class: 'btn btn-outline-primary d-block w-100'

--- a/backend/app/views/admin/images/_image_row.html.haml
+++ b/backend/app/views/admin/images/_image_row.html.haml
@@ -12,16 +12,12 @@
       = image.title
     - else
       %span.text-muted （無題）
-  %td
-    - if image.is_published?
-      %span.badge.text-bg-success 公開中
-    - else
-      %span.badge.text-bg-secondary 下書き
+  %td= render 'admin/images/status_badge', image: image
   %td
     .d-flex.gap-1
       - if image.is_published?
         = button_to '非公開にする', toggle_publish_admin_image_path(image), method: :patch, class: 'btn btn-outline-secondary btn-sm'
-      - else
+      - elsif image.publishable?
         = button_to '公開する', toggle_publish_admin_image_path(image), method: :patch, class: 'btn btn-outline-success btn-sm'
       = link_to '閲覧', admin_image_path(image), class: 'btn btn-primary btn-sm'
       = link_to '編集', edit_admin_image_path(image), class: 'btn btn-secondary btn-sm'

--- a/backend/app/views/admin/images/_image_row.html.haml
+++ b/backend/app/views/admin/images/_image_row.html.haml
@@ -7,7 +7,22 @@
       = image_tag(image.thumbnail_variant, alt: "#{image.title} preview", style: "height: 64px; width: auto;")
     - else
       %span.text-muted プレビューなし
-  %td= image.title
-  %td= link_to '閲覧', admin_image_path(image), class: 'btn btn-primary btn-sm'
-  %td= link_to '編集', edit_admin_image_path(image), class: 'btn btn-secondary btn-sm'
-  %td= button_to '削除', admin_image_path(image), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-danger btn-sm'
+  %td
+    - if image.title.present?
+      = image.title
+    - else
+      %span.text-muted （無題）
+  %td
+    - if image.is_published?
+      %span.badge.text-bg-success 公開中
+    - else
+      %span.badge.text-bg-secondary 下書き
+  %td
+    .d-flex.gap-1
+      - if image.is_published?
+        = button_to '非公開にする', toggle_publish_admin_image_path(image), method: :patch, class: 'btn btn-outline-secondary btn-sm'
+      - else
+        = button_to '公開する', toggle_publish_admin_image_path(image), method: :patch, class: 'btn btn-outline-success btn-sm'
+      = link_to '閲覧', admin_image_path(image), class: 'btn btn-primary btn-sm'
+      = link_to '編集', edit_admin_image_path(image), class: 'btn btn-secondary btn-sm'
+      = button_to '削除', admin_image_path(image), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-danger btn-sm'

--- a/backend/app/views/admin/images/_status_badge.html.haml
+++ b/backend/app/views/admin/images/_status_badge.html.haml
@@ -1,0 +1,6 @@
+- if image.is_published?
+  %span.badge.text-bg-success 公開中
+- elsif image.publishable?
+  %span.badge.text-bg-secondary 下書き
+- else
+  %span.badge.text-bg-warning 未編集

--- a/backend/app/views/admin/images/edit.html.haml
+++ b/backend/app/views/admin/images/edit.html.haml
@@ -1,6 +1,7 @@
 %h1 画像の情報を編集
 
-= render 'form', image: @image, cameras: @cameras, lenses: @lenses, categories: @categories, next_draft_exists: @next_draft_exists
+= render 'form', image: @image, cameras: @cameras, lenses: @lenses, categories: @categories,
+                 prev_image: @prev_image, next_image: @next_image, images_total: @images_total
 
 = link_to '閲覧', admin_image_path(@image)
 \|

--- a/backend/app/views/admin/images/edit.html.haml
+++ b/backend/app/views/admin/images/edit.html.haml
@@ -1,6 +1,6 @@
 %h1 画像の情報を編集
 
-= render 'form', image: @image, cameras: @cameras, lenses: @lenses, categories: @categories
+= render 'form', image: @image, cameras: @cameras, lenses: @lenses, categories: @categories, next_draft_exists: @next_draft_exists
 
 = link_to '閲覧', admin_image_path(@image)
 \|

--- a/backend/app/views/admin/images/index.html.haml
+++ b/backend/app/views/admin/images/index.html.haml
@@ -3,6 +3,14 @@
 - if flash.notice
   .alert.alert-info= flash[:notice]
 
+- if @uncurated_count.positive?
+  .alert.alert-warning
+    = "未編集の下書きが #{@uncurated_count} 枚あります。"
+    - if params[:filter] == "uncurated"
+      = link_to 'すべて表示', admin_images_path
+    - else
+      = link_to '下書きのみ表示', admin_images_path(filter: "uncurated")
+
 .table-responsive
   %table.table.table-striped{"data-controller": "sortable"}
     %thead
@@ -19,3 +27,4 @@
         = render 'image_row', image: image
 
 = link_to '新規作成', new_admin_image_path, class: 'btn btn-primary mt-3'
+= link_to '一括取り込み', new_admin_image_bulk_import_path, class: 'btn btn-outline-primary mt-3 ms-2'

--- a/backend/app/views/admin/images/index.html.haml
+++ b/backend/app/views/admin/images/index.html.haml
@@ -3,6 +3,9 @@
 - if flash.notice
   .alert.alert-info= flash[:notice]
 
+- if flash.alert
+  .alert.alert-danger= flash[:alert]
+
 - if @uncurated_count.positive?
   .alert.alert-warning
     = "未編集の下書きが #{@uncurated_count} 枚あります。"
@@ -18,9 +21,8 @@
         %th 表示順
         %th プレビュー
         %th タイトル
-        %th 閲覧
-        %th 編集
-        %th 削除
+        %th 公開状態
+        %th 操作
     %tbody{"data-sortable-target": "list",
            "data-sortable-update-url-value": insert_at_admin_image_path(":id")}
       - @images.each do |image|

--- a/backend/app/views/admin/images/index.html.haml
+++ b/backend/app/views/admin/images/index.html.haml
@@ -1,11 +1,5 @@
 %h1 画像一覧
 
-- if flash.notice
-  .alert.alert-info= flash[:notice]
-
-- if flash.alert
-  .alert.alert-danger= flash[:alert]
-
 - if @uncurated_count.positive?
   .alert.alert-warning
     = "未編集の下書きが #{@uncurated_count} 枚あります。"

--- a/backend/app/views/admin/images/show.html.haml
+++ b/backend/app/views/admin/images/show.html.haml
@@ -20,8 +20,8 @@
   .col-md-3.fw-bold Lens
   .col-md-9= @image.lens&.name
 .row.py-1
-  .col-md-3.fw-bold Is published
-  .col-md-9= @image.is_published
+  .col-md-3.fw-bold 公開状態
+  .col-md-9= render 'admin/images/status_badge', image: @image
 
 = link_to '編集', edit_admin_image_path(@image)
 \|

--- a/backend/app/views/admin/lenses/index.html.haml
+++ b/backend/app/views/admin/lenses/index.html.haml
@@ -1,8 +1,5 @@
 %h1 レンズ一覧
 
-- if flash.notice
-  .alert.alert-info= flash[:notice]
-
 .table-responsive
   %table.table.table-striped
     %thead

--- a/backend/app/views/admin/projects/index.html.haml
+++ b/backend/app/views/admin/projects/index.html.haml
@@ -1,10 +1,5 @@
 %h1 プロジェクト一覧
 
-- if flash.notice
-  .alert.alert-info= flash[:notice]
-- if flash.alert
-  .alert.alert-danger= flash[:alert]
-
 .table-responsive
   %table.table.table-striped
     %thead

--- a/backend/app/views/layouts/application.html.haml
+++ b/backend/app/views/layouts/application.html.haml
@@ -36,5 +36,9 @@
               %a.nav-link{:href => "/admin/categories"} カテゴリ
             %li.nav-item
               %a.nav-link{:href => "/admin/projects"} プロジェクト
-    .container
+    .container.mt-3
+      - if flash.notice
+        .alert.alert-info= flash.notice
+      - if flash.alert
+        .alert.alert-danger= flash.alert
       = yield

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :images do
       member do
         post :insert_at
+        patch :toggle_publish
       end
       collection do
         post :extract_exif

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         post :extract_exif
       end
     end
+    resource :image_bulk_import, only: %i[new create]
     resources :cameras
     resources :lenses
     resources :categories

--- a/backend/db/migrate/20260702060000_relax_image_constraints_for_draft_workflow.rb
+++ b/backend/db/migrate/20260702060000_relax_image_constraints_for_draft_workflow.rb
@@ -1,0 +1,11 @@
+class RelaxImageConstraintsForDraftWorkflow < ActiveRecord::Migration[8.1]
+  # Bulk ingest creates title-less/caption-less drafts, so publish-quality
+  # requirements move to the model layer (validated only when is_published).
+  # Publishing becomes an explicit act: the DB default flips to draft.
+  def change
+    change_column_null :images, :title, true
+    change_column_null :images, :caption, true
+    change_column_null :images, :taken_at, true
+    change_column_default :images, :is_published, from: true, to: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_060000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -78,13 +78,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_090000) do
 
   create_table "images", force: :cascade do |t|
     t.bigint "camera_id"
-    t.string "caption", null: false
+    t.string "caption"
     t.datetime "created_at", null: false
-    t.boolean "is_published", default: true, null: false
+    t.boolean "is_published", default: false, null: false
     t.bigint "lens_id"
     t.integer "row_order"
-    t.datetime "taken_at", null: false
-    t.string "title", null: false
+    t.datetime "taken_at"
+    t.string "title"
     t.datetime "updated_at", null: false
     t.index ["camera_id"], name: "index_images_on_camera_id"
     t.index ["is_published"], name: "index_images_on_is_published"

--- a/backend/spec/factories/image.rb
+++ b/backend/spec/factories/image.rb
@@ -8,5 +8,15 @@ FactoryBot.define do
     is_published { true }
     camera { build(:camera) }
     lens { build(:lens) }
+
+    # Fresh bulk-ingested state: nothing curated yet, metadata to be filled by EXIF.
+    trait :draft do
+      title { nil }
+      caption { nil }
+      taken_at { nil }
+      is_published { false }
+      camera { nil }
+      lens { nil }
+    end
   end
 end

--- a/backend/spec/models/image_spec.rb
+++ b/backend/spec/models/image_spec.rb
@@ -188,6 +188,19 @@ RSpec.describe Image, type: :model do
     end
   end
 
+  describe '#publishable?' do
+    it 'is true when all publish requirements (title, taken_at) are present' do
+      image = build(:image, is_published: false)
+
+      expect(image.publishable?).to be(true)
+    end
+
+    it 'is false when title or taken_at is blank' do
+      expect(build(:image, title: nil).publishable?).to be(false)
+      expect(build(:image, taken_at: nil).publishable?).to be(false)
+    end
+  end
+
   describe '.for_gallery' do
     let!(:img1) { create(:image, title: 'A', row_order: 0, is_published: true) }
     let!(:img2) { create(:image, title: 'B', row_order: 1, is_published: true) }

--- a/backend/spec/models/image_spec.rb
+++ b/backend/spec/models/image_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Image, type: :model do
   let(:image) { build(:image) }
 
   describe 'validations' do
+    # Isolate validation behavior from the EXIF auto-fill hook (tested separately
+    # below) — otherwise the fixture's real EXIF would refill a blanked taken_at.
+    before { allow(ExifExtractor).to receive(:from_blob).and_return(ExifExtractor::EMPTY) }
+
     context 'file' do
       it 'should be valid with file' do
         image.file = Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/test_image.jpg"), 'image/jpeg')
@@ -16,15 +20,24 @@ RSpec.describe Image, type: :model do
       end
     end
 
+    # title/taken_at are publish-quality requirements: required when published,
+    # free to be blank while the record lives as a draft (bulk ingest).
     context 'title' do
       it 'should be valid with title' do
         image.title = 'Test Image'
         expect(image).to be_valid
       end
 
-      it 'should be invalid with blank title' do
+      it 'should be invalid with blank title when published' do
+        image.is_published = true
         image.title = ''
         expect(image).to be_invalid
+      end
+
+      it 'should be valid with blank title when draft' do
+        image.is_published = false
+        image.title = ''
+        expect(image).to be_valid
       end
     end
 
@@ -34,9 +47,10 @@ RSpec.describe Image, type: :model do
         expect(image).to be_valid
       end
 
-      it 'should be invalid with blank caption' do
+      it 'should be valid with blank caption even when published' do
+        image.is_published = true
         image.caption = ''
-        expect(image).to be_invalid
+        expect(image).to be_valid
       end
     end
 
@@ -46,9 +60,16 @@ RSpec.describe Image, type: :model do
         expect(image).to be_valid
       end
 
-      it 'should be invalid with nil taken_at' do
+      it 'should be invalid with nil taken_at when published' do
+        image.is_published = true
         image.taken_at = nil
         expect(image).to be_invalid
+      end
+
+      it 'should be valid with nil taken_at when draft' do
+        image.is_published = false
+        image.taken_at = nil
+        expect(image).to be_valid
       end
 
       it 'should be invalid with future taken_at' do
@@ -109,6 +130,61 @@ RSpec.describe Image, type: :model do
         image.categories << category
         expect(image).to be_valid
       end
+    end
+  end
+
+  describe 'EXIF metadata auto-fill on create' do
+    let(:exif_blob) do
+      ActiveStorage::Blob.create_and_upload!(
+        io: Rails.root.join('spec/fixtures/files/test_image.jpg').open,
+        filename: 'test_image.jpg', content_type: 'image/jpeg'
+      )
+    end
+
+    it 'fills taken_at, camera and lens for a draft created without them' do
+      image = Image.create!(file: exif_blob.signed_id, is_published: false)
+
+      expect(image.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
+      expect(image.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
+      expect(image.lens).to have_attributes(exif_name: 'FE 85mm F1.8')
+    end
+
+    it 'does not overwrite human-provided values' do
+      camera = create(:camera)
+      lens = create(:lens)
+      taken_at = 2.days.ago.change(usec: 0)
+
+      image = Image.create!(file: exif_blob.signed_id, is_published: false,
+                            taken_at: taken_at, camera: camera, lens: lens)
+
+      expect(image.taken_at).to eq(taken_at)
+      expect(image.camera).to eq(camera)
+      expect(image.lens).to eq(lens)
+    end
+
+    it 'still saves a draft when the file has no EXIF (fail-open)' do
+      blank_blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new(Vips::Image.black(4, 4).write_to_buffer('.jpg')),
+        filename: 'blank.jpg', content_type: 'image/jpeg'
+      )
+
+      image = Image.create!(file: blank_blob.signed_id, is_published: false)
+
+      expect(image).to be_persisted
+      expect(image.taken_at).to be_nil
+      expect(image.camera).to be_nil
+      expect(image.lens).to be_nil
+    end
+  end
+
+  describe '.uncurated' do
+    it 'returns only drafts without a title' do
+      untitled_draft = create(:image, :draft)
+      titled_draft = create(:image, title: 'done', is_published: false)
+      published = create(:image, is_published: true)
+
+      expect(Image.uncurated).to include(untitled_draft)
+      expect(Image.uncurated).not_to include(titled_draft, published)
     end
   end
 

--- a/backend/spec/requests/admin/image_bulk_imports_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_imports_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::ImageBulkImports', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user, :admin) }
+
+  before { sign_in user }
+
+  def upload_fixture_blob
+    ActiveStorage::Blob.create_and_upload!(
+      io: Rails.root.join('spec/fixtures/files/test_image.jpg').open,
+      filename: 'test_image.jpg',
+      content_type: 'image/jpeg'
+    )
+  end
+
+  describe 'GET /admin/image_bulk_import/new' do
+    it 'renders the bulk import form' do
+      get '/admin/image_bulk_import/new'
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('画像の一括取り込み')
+    end
+  end
+
+  describe 'POST /admin/image_bulk_import' do
+    it 'creates a draft per file with EXIF metadata and shared categories' do
+      category = create(:category)
+      signed_ids = [upload_fixture_blob.signed_id, upload_fixture_blob.signed_id]
+
+      expect do
+        post '/admin/image_bulk_import',
+             params: { bulk: { files: signed_ids, category_ids: [category.id] } }
+      end.to change(Image, :count).by(2)
+
+      expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
+
+      drafts = Image.order(:id).last(2)
+      drafts.each do |draft|
+        expect(draft.is_published).to be(false)
+        expect(draft.title).to be_nil
+        expect(draft.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
+        expect(draft.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
+        expect(draft.categories).to eq([category])
+      end
+    end
+
+    it 'isolates failures per file: valid files are ingested, invalid ones reported' do
+      signed_ids = [upload_fixture_blob.signed_id, 'bogus-signed-id']
+
+      expect do
+        post '/admin/image_bulk_import', params: { bulk: { files: signed_ids } }
+      end.to change(Image, :count).by(1)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('1枚の取り込みに失敗しました')
+    end
+
+    it 'rejects a submission without files' do
+      expect do
+        post '/admin/image_bulk_import', params: { bulk: { files: [] } }
+      end.not_to change(Image, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+end

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -53,18 +53,18 @@ RSpec.describe 'Admin::Images', type: :request do
       expect(flash[:notice]).to include('公開しました')
     end
 
-    it 'rejects publishing an uncurated draft and surfaces the errors' do
-      draft = create(:image, :draft, row_order: 500)
+    it 'redirects an unpublishable draft to the edit form instead of publishing' do
+      draft = create(:image, :draft, taken_at: nil, row_order: 500)
 
       patch "/admin/images/#{draft.id}/toggle_publish"
 
-      expect(response).to redirect_to(admin_images_path)
+      expect(response).to redirect_to(edit_admin_image_path(draft))
       expect(draft.reload.is_published).to be(false)
-      expect(flash[:alert]).to include('公開できません')
+      expect(flash[:alert]).to include('タイトルと撮影日時が必要')
     end
 
     it 'redirects back to the filtered index when toggled from there' do
-      draft = create(:image, :draft, row_order: 500)
+      draft = create(:image, :draft, title: 'Curated', taken_at: 1.day.ago, row_order: 500)
 
       patch "/admin/images/#{draft.id}/toggle_publish",
             headers: { 'HTTP_REFERER' => admin_images_url(filter: 'uncurated') }
@@ -74,15 +74,74 @@ RSpec.describe 'Admin::Images', type: :request do
   end
 
   describe 'GET /admin/images publish status column' do
-    it 'shows publish state badges and toggle buttons' do
-      create(:image, :draft, row_order: 500)
+    it 'shows badges and offers the publish button only for publishable drafts' do
+      create(:image, :draft, title: 'Curated Draft', taken_at: 1.day.ago, row_order: 500)
+      uncurated = create(:image, :draft, taken_at: nil, row_order: 600)
 
       get '/admin/images'
 
       expect(response.body).to include('公開中')
       expect(response.body).to include('下書き')
-      expect(response.body).to include('公開する')
+      expect(response.body).to include('未編集')
       expect(response.body).to include('非公開にする')
+      # 公開ボタンは publishable な下書き1件分だけ
+      expect(response.body.scan('公開する').size).to eq(1)
+      expect(uncurated.reload.publishable?).to be(false)
+    end
+  end
+
+  describe 'POST /admin/images (publish via submit buttons)' do
+    let(:file) { fixture_file_upload('test_image.jpg', 'image/jpeg') }
+
+    it 'creates a draft with 下書きとして保存' do
+      post '/admin/images', params: { commit_draft: '下書きとして保存', image: { title: 'New Draft', file: file } }
+
+      expect(Image.order(:id).last).to have_attributes(title: 'New Draft', is_published: false)
+    end
+
+    it 'creates a published image with 公開して保存' do
+      post '/admin/images',
+           params: { commit_publish: '公開して保存',
+                     image: { title: 'New Published', taken_at: 1.day.ago, file: file } }
+
+      expect(Image.order(:id).last).to have_attributes(title: 'New Published', is_published: true)
+    end
+  end
+
+  describe 'PATCH /admin/images/:id (publish via submit buttons)' do
+    let!(:draft) { create(:image, :draft, row_order: 500) }
+
+    it 'publishes with 公開して保存 once curated' do
+      patch "/admin/images/#{draft.id}",
+            params: { commit_publish: '公開して保存', image: { title: 'Curated', taken_at: '2026-01-01T10:00' } }
+
+      expect(draft.reload.is_published).to be(true)
+    end
+
+    it 're-renders as draft when publish requirements are missing' do
+      patch "/admin/images/#{draft.id}", params: { commit_publish: '公開して保存', image: { title: '' } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(draft.reload.is_published).to be(false)
+      # 再描画されたフォームは下書き状態のボタンを出す
+      expect(response.body).to include('下書きとして保存')
+    end
+
+    it 'unpublishes a published image with 非公開にして保存' do
+      patch "/admin/images/#{image1.id}", params: { commit_draft: '非公開にして保存', image: { title: image1.title } }
+
+      expect(image1.reload.is_published).to be(false)
+    end
+
+    it 'publishes and advances to the next draft with 公開して次へ' do
+      next_draft = create(:image, :draft, row_order: 600)
+
+      patch "/admin/images/#{draft.id}",
+            params: { publish_and_next: '公開して次へ', image: { title: 'Curated', taken_at: '2026-01-01T10:00' } }
+
+      expect(draft.reload.is_published).to be(true)
+      expect(response).to redirect_to(edit_admin_image_path(next_draft))
+      expect(flash[:notice]).to include('公開しました')
     end
   end
 

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -13,6 +13,26 @@ RSpec.describe 'Admin::Images', type: :request do
     create(:image, title: 'Test Image 4', row_order: 400, id: 4)
   end
 
+  describe 'GET /admin/images' do
+    it 'renders and surfaces the uncurated draft count with a filter link' do
+      create(:image, :draft, row_order: 500)
+
+      get '/admin/images'
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('未編集の下書きが 1 枚あります')
+    end
+
+    it 'filters to uncurated drafts only' do
+      draft = create(:image, :draft, row_order: 500)
+
+      get '/admin/images', params: { filter: 'uncurated' }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("data-image-id='#{draft.id}'").or include("data-image-id=\"#{draft.id}\"")
+    end
+  end
+
   describe 'POST /admin/images/:id/insert_at' do
     it 'should insert the image at the given position' do
       expect(Image.rank(:row_order).pluck(:id)).to eq([1, 2, 3, 4])
@@ -50,6 +70,33 @@ RSpec.describe 'Admin::Images', type: :request do
 
       expect(response).to have_http_status(:success)
       expect(response.parsed_body).to eq('taken_at' => nil, 'camera' => nil, 'lens' => nil)
+    end
+  end
+
+  describe 'PATCH /admin/images/:id with save_and_next' do
+    let!(:draft_a) { create(:image, :draft, row_order: 500) }
+    let!(:draft_b) { create(:image, :draft, row_order: 600) }
+
+    it 'redirects to the next uncurated draft after saving' do
+      patch "/admin/images/#{draft_a.id}",
+            params: { save_and_next: '1', image: { title: 'Titled now' } }
+
+      expect(response).to redirect_to(edit_admin_image_path(draft_b))
+    end
+
+    it 'redirects to the index when no uncurated drafts remain' do
+      draft_b.update!(title: 'already titled')
+
+      patch "/admin/images/#{draft_a.id}",
+            params: { save_and_next: '1', image: { title: 'Titled now' } }
+
+      expect(response).to redirect_to(admin_images_path)
+    end
+
+    it 'keeps the normal redirect when save_and_next is absent' do
+      patch "/admin/images/#{draft_a.id}", params: { image: { title: 'Titled now' } }
+
+      expect(response).to redirect_to(admin_images_path(draft_a, format: nil))
     end
   end
 end

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -93,15 +93,15 @@ RSpec.describe 'Admin::Images', type: :request do
   describe 'POST /admin/images (publish via submit buttons)' do
     let(:file) { fixture_file_upload('test_image.jpg', 'image/jpeg') }
 
-    it 'creates a draft with 下書きとして保存' do
-      post '/admin/images', params: { commit_draft: '下書きとして保存', image: { title: 'New Draft', file: file } }
+    it 'creates a draft with plain 保存' do
+      post '/admin/images', params: { image: { title: 'New Draft', file: file } }
 
       expect(Image.order(:id).last).to have_attributes(title: 'New Draft', is_published: false)
     end
 
-    it 'creates a published image with 公開して保存' do
+    it 'creates a published image with 公開する' do
       post '/admin/images',
-           params: { commit_publish: '公開して保存',
+           params: { commit_publish: '公開する',
                      image: { title: 'New Published', taken_at: 1.day.ago, file: file } }
 
       expect(Image.order(:id).last).to have_attributes(title: 'New Published', is_published: true)
@@ -111,37 +111,59 @@ RSpec.describe 'Admin::Images', type: :request do
   describe 'PATCH /admin/images/:id (publish via submit buttons)' do
     let!(:draft) { create(:image, :draft, row_order: 500) }
 
-    it 'publishes with 公開して保存 once curated' do
+    it 'publishes with 公開する and stays on the card' do
       patch "/admin/images/#{draft.id}",
-            params: { commit_publish: '公開して保存', image: { title: 'Curated', taken_at: '2026-01-01T10:00' } }
+            params: { commit_publish: '公開する', image: { title: 'Curated', taken_at: '2026-01-01T10:00' } }
 
       expect(draft.reload.is_published).to be(true)
+      expect(response).to redirect_to(edit_admin_image_path(draft))
+      expect(flash[:notice]).to include('公開しました')
     end
 
     it 're-renders as draft when publish requirements are missing' do
-      patch "/admin/images/#{draft.id}", params: { commit_publish: '公開して保存', image: { title: '' } }
+      patch "/admin/images/#{draft.id}", params: { commit_publish: '公開する', image: { title: '' } }
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(draft.reload.is_published).to be(false)
-      # 再描画されたフォームは下書き状態のボタンを出す
-      expect(response.body).to include('下書きとして保存')
+      # 再描画されたフォームは下書き状態のボタン（公開する）を出す
+      expect(response.body).to include('公開する')
     end
 
-    it 'unpublishes a published image with 非公開にして保存' do
-      patch "/admin/images/#{image1.id}", params: { commit_draft: '非公開にして保存', image: { title: image1.title } }
+    it 'unpublishes a published image with 非公開に戻す' do
+      patch "/admin/images/#{image1.id}", params: { commit_draft: '非公開に戻す', image: { title: image1.title } }
 
       expect(image1.reload.is_published).to be(false)
+      expect(response).to redirect_to(edit_admin_image_path(image1))
+    end
+  end
+
+  describe 'PATCH /admin/images/:id (card navigation)' do
+    it 'saves and moves to the next image in display order with 次へ' do
+      patch "/admin/images/#{image2.id}", params: { nav_next: '次へ →', image: { title: 'Renamed' } }
+
+      expect(image2.reload.title).to eq('Renamed')
+      expect(response).to redirect_to(edit_admin_image_path(image3))
     end
 
-    it 'publishes and advances to the next draft with 公開して次へ' do
-      next_draft = create(:image, :draft, row_order: 600)
+    it 'saves and moves to the previous image with 前へ' do
+      patch "/admin/images/#{image2.id}", params: { nav_prev: '← 前へ', image: { title: 'Renamed' } }
 
-      patch "/admin/images/#{draft.id}",
-            params: { publish_and_next: '公開して次へ', image: { title: 'Curated', taken_at: '2026-01-01T10:00' } }
+      expect(response).to redirect_to(edit_admin_image_path(image1))
+    end
 
-      expect(draft.reload.is_published).to be(true)
-      expect(response).to redirect_to(edit_admin_image_path(next_draft))
-      expect(flash[:notice]).to include('公開しました')
+    it 'stays on the current card after a plain 保存' do
+      patch "/admin/images/#{image2.id}", params: { image: { title: 'Renamed' } }
+
+      expect(response).to redirect_to(edit_admin_image_path(image2))
+      expect(flash[:notice]).to include('保存しました')
+    end
+
+    it 'disables 前へ on the first card and 次へ on the last card' do
+      get "/admin/images/#{image1.id}/edit"
+      expect(response.body).to match(/nav_prev[^>]*disabled/)
+
+      get "/admin/images/#{image4.id}/edit"
+      expect(response.body).to match(/nav_next[^>]*disabled/)
     end
   end
 
@@ -185,30 +207,14 @@ RSpec.describe 'Admin::Images', type: :request do
     end
   end
 
-  describe 'PATCH /admin/images/:id with save_and_next' do
-    let!(:draft_a) { create(:image, :draft, row_order: 500) }
-    let!(:draft_b) { create(:image, :draft, row_order: 600) }
+  describe 'GET /admin/images/:id/edit' do
+    it 'shows the image preview and card position on the edit card' do
+      get "/admin/images/#{image2.id}/edit"
 
-    it 'redirects to the next uncurated draft after saving' do
-      patch "/admin/images/#{draft_a.id}",
-            params: { save_and_next: '1', image: { title: 'Titled now' } }
-
-      expect(response).to redirect_to(edit_admin_image_path(draft_b))
-    end
-
-    it 'redirects to the index when no uncurated drafts remain' do
-      draft_b.update!(title: 'already titled')
-
-      patch "/admin/images/#{draft_a.id}",
-            params: { save_and_next: '1', image: { title: 'Titled now' } }
-
-      expect(response).to redirect_to(admin_images_path)
-    end
-
-    it 'keeps the normal redirect when save_and_next is absent' do
-      patch "/admin/images/#{draft_a.id}", params: { image: { title: 'Titled now' } }
-
-      expect(response).to redirect_to(admin_images_path(draft_a, format: nil))
+      expect(response).to have_http_status(:success)
+      # プレビュー画像（Active Storage の representation URL）が描画される
+      expect(response.body).to include('/rails/active_storage/representations/')
+      expect(response.body).to include('2 / 4 枚目')
     end
   end
 end

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe 'Admin::Images', type: :request do
 
   let(:user) { create(:user, :admin) }
 
-  before do
-    sign_in user
-    create(:image, title: 'Test Image 1', row_order: 100, id: 1)
-    create(:image, title: 'Test Image 2', row_order: 200, id: 2)
-    create(:image, title: 'Test Image 3', row_order: 300, id: 3)
-    create(:image, title: 'Test Image 4', row_order: 400, id: 4)
-  end
+  # NOTE: id を固定して create すると PG のシーケンスが進まず、
+  # 以降の自動採番 create が duplicate key で落ちるため自動採番に任せる。
+  let!(:image1) { create(:image, title: 'Test Image 1', row_order: 100) }
+  let!(:image2) { create(:image, title: 'Test Image 2', row_order: 200) }
+  let!(:image3) { create(:image, title: 'Test Image 3', row_order: 300) }
+  let!(:image4) { create(:image, title: 'Test Image 4', row_order: 400) }
+
+  before { sign_in user }
 
   describe 'GET /admin/images' do
     it 'renders and surfaces the uncurated draft count with a filter link' do
@@ -33,14 +34,66 @@ RSpec.describe 'Admin::Images', type: :request do
     end
   end
 
+  describe 'PATCH /admin/images/:id/toggle_publish' do
+    it 'unpublishes a published image' do
+      patch "/admin/images/#{image1.id}/toggle_publish"
+
+      expect(response).to redirect_to(admin_images_path)
+      expect(image1.reload.is_published).to be(false)
+      expect(flash[:notice]).to include('非公開にしました')
+    end
+
+    it 'publishes a curated draft' do
+      draft = create(:image, :draft, title: 'Curated', taken_at: 1.day.ago, row_order: 500)
+
+      patch "/admin/images/#{draft.id}/toggle_publish"
+
+      expect(response).to redirect_to(admin_images_path)
+      expect(draft.reload.is_published).to be(true)
+      expect(flash[:notice]).to include('公開しました')
+    end
+
+    it 'rejects publishing an uncurated draft and surfaces the errors' do
+      draft = create(:image, :draft, row_order: 500)
+
+      patch "/admin/images/#{draft.id}/toggle_publish"
+
+      expect(response).to redirect_to(admin_images_path)
+      expect(draft.reload.is_published).to be(false)
+      expect(flash[:alert]).to include('公開できません')
+    end
+
+    it 'redirects back to the filtered index when toggled from there' do
+      draft = create(:image, :draft, row_order: 500)
+
+      patch "/admin/images/#{draft.id}/toggle_publish",
+            headers: { 'HTTP_REFERER' => admin_images_url(filter: 'uncurated') }
+
+      expect(response).to redirect_to(admin_images_url(filter: 'uncurated'))
+    end
+  end
+
+  describe 'GET /admin/images publish status column' do
+    it 'shows publish state badges and toggle buttons' do
+      create(:image, :draft, row_order: 500)
+
+      get '/admin/images'
+
+      expect(response.body).to include('公開中')
+      expect(response.body).to include('下書き')
+      expect(response.body).to include('公開する')
+      expect(response.body).to include('非公開にする')
+    end
+  end
+
   describe 'POST /admin/images/:id/insert_at' do
     it 'should insert the image at the given position' do
-      expect(Image.rank(:row_order).pluck(:id)).to eq([1, 2, 3, 4])
+      expect(Image.rank(:row_order).pluck(:id)).to eq([image1.id, image2.id, image3.id, image4.id])
 
-      post "/admin/images/1/insert_at", params: { position: 2 }
+      post "/admin/images/#{image1.id}/insert_at", params: { position: 2 }
       expect(response).to have_http_status(:success)
 
-      expect(Image.rank(:row_order).pluck(:id)).to eq([2, 3, 1, 4])
+      expect(Image.rank(:row_order).pluck(:id)).to eq([image2.id, image3.id, image1.id, image4.id])
     end
   end
 


### PR DESCRIPTION
## 概要
#199 の中核を実装: 複数ファイルを下書きとして一括取り込み（EXIF はモデル層で自動補完）し、Save & Next で1枚ずつキュレーションするワークフロー。

Refs #199（画面の実描画確認と e2e 追随が残るため Closes にしない）

## レビュー優先度
🔴 全文レビュー — バリデーション緩和・DB デフォルト変更・EXIF 解決の配線変更を含む

## 判断・トレードオフ（独断で決めた点。異議があれば戻します）

1. **taken_at も「公開時のみ必須」に緩和**（issue 本文は title/caption のみ言及）— EXIF なし画像（スキャン等）の下書き取り込みが DB/検証で弾かれないため。「レコード存在の要件 vs 公開品質の要件」の分離を3カラムに一貫適用
2. **is_published の DB デフォルトを true → false に変更** — 公開を明示的な操作にする。**単発の新規作成フォームも今後はデフォルト下書きになる**（挙動変更）
3. **EXIF 自動補完は before_validation（blob 永続時のみ・空欄のみ補完）** — after_commit + update_columns 案と比較し、direct upload 系の全経路（フォーム/一括/API）で検証前に値が入り、バリデーション迂回がない方を採用。io 添付（console 等）はスキップされる（rake 取り込みは create_and_upload! 経由にすれば乗る）。#205 の残ギャップの根治
4. **一括取り込みは Admin::ImageBulkImportsController に分離** — images_controller の肥大化（rubocop ClassLength）と責務分離のため。ルートは `resource :image_bulk_import`

失敗ハンドリングはファイル単位で隔離（不正 signed_id は該当ファイルのみ失敗として報告）。想定外の例外（S3 障害等）は握りつぶさず 500 で表面化させる（fail-loud）。

## 確認
- rspec 91 examples, 0 failures（一括取り込みの成功/部分失敗/空 submit、Save & Next の遷移3パターン、EXIF 自動補完の3ケース、緩和後バリデーション、index/一括フォームの描画を含む）
- rubocop フルスキャン clean
- **未確認: ブラウザでの実描画・direct upload の複数ファイル動作**（ユーザーが手元で確認予定）。既存 e2e image-create.spec.ts は単発フォームのフロー無変更のため影響なし想定、一括取り込みの e2e は未追加

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)