### PR TITLE
feat: プロジェクトに説明・タグ(tags)を追加

### DIFF
--- a/backend/app/controllers/admin/projects_controller.rb
+++ b/backend/app/controllers/admin/projects_controller.rb
@@ -45,6 +45,6 @@ class Admin::ProjectsController < Admin::Base
   end
 
   def project_params
-    params.expect(project: %i[title link file])
+    params.expect(project: %i[title link file description tags])
   end
 end

--- a/backend/app/controllers/api/projects_controller.rb
+++ b/backend/app/controllers/api/projects_controller.rb
@@ -9,7 +9,7 @@ class Api::ProjectsController < ApplicationController
   def project_json(project)
     width, height = file_dimensions(project.file)
 
-    project.as_json(only: %i[id title link]).merge(
+    project.as_json(only: %i[id title link description tags]).merge(
       file: project.display_url,
       thumbnail: project.thumbnail_url,
       width: width,

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -8,4 +8,10 @@ class Project < ApplicationRecord
 
   validates :title, presence: true
   validates :link, presence: true, format: { with: %r{\Ahttps?://.+\z}, message: "は正しいURLの形式で入力してください (http:// または https:// で始まる必要があります)" }
+
+  # Admin form submits tags as a comma-separated string.
+  def tags=(value)
+    value = value.split(",").map(&:strip).reject(&:empty?) if value.is_a?(String)
+    super
+  end
 end

--- a/backend/app/views/admin/projects/_form.html.haml
+++ b/backend/app/views/admin/projects/_form.html.haml
@@ -11,6 +11,16 @@
     .col-md-3.col-form-label.fw-bold link
     .col-md-9= form.url_field :link, class: 'form-control'
   .row.mb-3
+    .col-md-3.col-form-label.fw-bold description
+    .col-md-9
+      = form.text_area :description, rows: 4, class: 'form-control'
+      %small.text-muted 何を・なぜ・どんな役割で作ったか（2〜3文）
+  .row.mb-3
+    .col-md-3.col-form-label.fw-bold tags
+    .col-md-9
+      = form.text_field :tags, value: project.tags.join(', '), class: 'form-control', placeholder: 'Rails, Next.js, 個人開発, 記事'
+      %small.text-muted カンマ区切りで入力（技術に限らず「個人開発」「記事」「写真活動」等の性質も可）
+  .row.mb-3
     .col-md-3.col-form-label.fw-bold file
     .col-md-9
       = form.file_field :file, direct_upload: true, class: 'form-control', data: { direct_upload_target: "input" }

--- a/backend/app/views/admin/projects/index.html.haml
+++ b/backend/app/views/admin/projects/index.html.haml
@@ -5,6 +5,8 @@
     %thead
       %tr
         %th プロジェクト名
+        %th 説明
+        %th タグ
         %th リンク
         %th 編集
         %th 削除
@@ -12,6 +14,8 @@
       - @projects.each do |project|
         %tr
           %td= project.title
+          %td= project.description.present? ? truncate(project.description, length: 40) : 'ー'
+          %td= project.tags.any? ? project.tags.join(', ') : 'ー'
           %td
             - if project.link.present?
               = link_to project.link, project.link, target: '_blank', rel: 'noreferrer'

--- a/backend/db/migrate/20260703000000_add_description_and_tags_to_projects.rb
+++ b/backend/db/migrate/20260703000000_add_description_and_tags_to_projects.rb
@@ -1,0 +1,8 @@
+class AddDescriptionAndTagsToProjects < ActiveRecord::Migration[8.1]
+  def change
+    change_table :projects, bulk: true do |t|
+      t.text :description
+      t.string :tags, array: true, default: [], null: false
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_060000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -103,7 +103,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_02_060000) do
 
   create_table "projects", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.text "description"
     t.string "link", null: false
+    t.string "tags", default: [], null: false, array: true
     t.string "title", null: false
     t.datetime "updated_at", null: false
   end

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -30,6 +30,27 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe '#tags=' do
+    it 'splits a comma-separated string into a trimmed array' do
+      project.tags = 'Rails, Next.js , PostgreSQL'
+      expect(project.tags).to eq(%w[Rails Next.js PostgreSQL])
+    end
+
+    it 'rejects empty entries from surplus commas' do
+      project.tags = 'Rails, , ,Next.js,'
+      expect(project.tags).to eq(%w[Rails Next.js])
+    end
+
+    it 'accepts an array as-is' do
+      project.tags = %w[Rails Next.js]
+      expect(project.tags).to eq(%w[Rails Next.js])
+    end
+
+    it 'defaults to an empty array' do
+      expect(build(:project).tags).to eq([])
+    end
+  end
+
   describe '#file_url' do
     context 'when file is not attached' do
       it 'returns nil' do

--- a/backend/spec/requests/api/projects_spec.rb
+++ b/backend/spec/requests/api/projects_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Projects API', type: :request do
   let!(:project_one) do
-    create(:project, title: 'Test Project 1', id: 1, link: 'https://example.com/project-1')
+    create(:project, title: 'Test Project 1', id: 1, link: 'https://example.com/project-1',
+                     description: 'A sample project', tags: %w[Rails Next.js])
   end
   let!(:project_two) do
     create(:project, title: 'Test Project 2', id: 2, link: 'https://example.com/project-2')
@@ -21,6 +22,14 @@ RSpec.describe 'Projects API', type: :request do
 
       links = projects.pluck('link')
       expect(links).to include(project_one.link, project_two.link)
+    end
+
+    it 'includes description and tags in each project' do
+      get '/api/projects'
+
+      project = response.parsed_body.find { |p| p['id'] == project_one.id }
+      expect(project['description']).to eq('A sample project')
+      expect(project['tags']).to eq(%w[Rails Next.js])
     end
   end
 end

--- a/frontend/src/app/projects/_components/ProjectCard.tsx
+++ b/frontend/src/app/projects/_components/ProjectCard.tsx
@@ -60,6 +60,21 @@ export default function ProjectCard({ project }: ProjectCardProps) {
             </span>
           )}
         </h3>
+        {project.description && (
+          <p className="text-sm leading-relaxed text-foreground/80">{project.description}</p>
+        )}
+        {project.tags.length > 0 && (
+          <ul className="mt-auto flex flex-wrap gap-2">
+            {project.tags.map((tag) => (
+              <li
+                key={tag}
+                className="rounded-full border border-accent-light/60 px-2.5 py-0.5 text-xs text-foreground/70"
+              >
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </>
   );

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -26,6 +26,8 @@ export type ProjectType = {
   id: number;
   title: string;
   link: string;
+  description: string | null;
+  tags: string[];
   file: string | null;
   thumbnail?: string | null;
   width?: number | null;


### PR DESCRIPTION
## 概要
Project に `description`(text) と `tags`(string array) を追加し、admin 編集・API・フロント表示まで通した。

Closes #195

## レビュー優先度
🔴 全文レビュー — 新カラム + setter + API フィールド + 描画を含む機能追加

## 判断・トレードオフ
- 「技術スタック」ではなく general な **tags** として持つ（技術に限らず「個人開発」「記事」「写真活動」等の性質も同じ仕組みで表現）。issue #195 の 2026-07-03 決定に従い、`kind`/`period` カラムや正規化(Tag モデル/acts-as-taggable-on)は導入しない。書き手 1 人・対象 1 モデルの現状では正規化が解決する問題がまだ無いため
- GIN インデックスは入れない。絞り込みが必要になった時点で array 演算子 `@>` + GIN で足りる
- admin フォームはカンマ区切りテキスト、model の `tags=` で strip + 空要素除去して配列化

## 確認
- backend rspec: model(`tags=` の strip/空要素除去/array素通し/default) + API(description・tags がレスポンスに含まれる) 追加、`13 examples, 0 failures`
- migration を dev/test DB に適用し schema.rb 反映を確認
- frontend tsc / eslint パス
- 未確認: 実ブラウザでの ProjectCard ピル描画・admin フォーム描画（ローカル 3000/3002 占有中のため保留）