### PR TITLE
feat: CD基盤を導入（GHCR push型 + Tailscale WIF、静的secretゼロ）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,100 @@
+# Deploy — GHCR にイメージを build/push し、Tailscale 経由で mr2 に反映する
+#
+# 認証はすべて短命トークン（静的 secret なし）:
+#   - GHCR push: ジョブ毎に自動発行される GITHUB_TOKEN
+#   - tailnet 参加: GitHub OIDC → Tailscale workload identity federation
+#   - mr2 への SSH: Tailscale SSH（ACL の ssh ルールで tag:ci → mr2 のみ許可）
+#
+# 事前セットアップ（Tailscale 管理画面・mr2 側の手順）は DEPLOY.md を参照。
+#
+# ロールバック: Actions の Run workflow から image_tag に過去の commit SHA を
+# 指定して手動実行すると、build をスキップしてそのイメージを再デプロイする。
+
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'docker-compose.prod.yml'
+      - 'bin/deploy'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'デプロイするイメージタグ（commit SHA）。空なら HEAD を build してデプロイ'
+        required: false
+        default: ''
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  build:
+    # ロールバック（image_tag 指定）時は build をスキップ
+    if: github.event_name == 'push' || inputs.image_tag == ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - service: backend
+            build_args: ''
+          - service: frontend
+            # NEXT_PUBLIC_* はクライアント JS に焼き込まれる公開値（mr2 の .env と同値を維持すること）
+            build_args: |
+              NEXT_PUBLIC_API_BASE_URL=https://api.kakemu.work/api
+              NEXT_PUBLIC_CLOUDFRONT_BASE_URL=https://d3dl8ofusrny5i.cloudfront.net
+              NEXT_PUBLIC_S3_HOSTNAME=
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: ./${{ matrix.service }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/portfolio-${{ matrix.service }}:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/portfolio-${{ matrix.service }}:latest
+          build-args: ${{ matrix.build_args }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,scope=${{ matrix.service }},mode=max
+
+  deploy:
+    needs: build
+    # build 成功時 or ロールバックで build がスキップされた時に実行
+    if: ${{ !cancelled() && !failure() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # Tailscale workload identity federation (OIDC)
+    env:
+      IMAGE_TAG: ${{ inputs.image_tag != '' && inputs.image_tag || github.sha }}
+    steps:
+      - name: Connect to tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ vars.TS_FEDERATED_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci
+
+      - name: Deploy to mr2
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            huji333@mr2 "~/portfolio/bin/deploy $IMAGE_TAG"

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,126 @@
+# CD セットアップ手順（GHCR + Tailscale WIF）
+
+main への push で GitHub Actions がイメージを GHCR に push し、Tailscale 経由で
+mr2 の `bin/deploy` を実行する。**静的な長期 credential はどこにも置かない**：
+
+| 経路 | 認証 |
+|---|---|
+| Actions → GHCR | ジョブ毎に自動発行される `GITHUB_TOKEN`（短命） |
+| Actions → tailnet | GitHub OIDC → Tailscale [workload identity federation](https://tailscale.com/kb/1581/workload-identity-federation)（短命） |
+| runner → mr2 SSH | Tailscale SSH（鍵レス、ACL で制御） |
+| mr2 → GHCR pull | 匿名（public package） |
+
+デプロイフロー: `build/push (GHCR)` → `tailnet 参加` → `ssh mr2 bin/deploy <sha>`
+→ `compose pull` → `DB バックアップ` → `migrate` → `up -d` → `healthcheck`（失敗で job 赤）
+
+## 初回セットアップ
+
+### 1. mr2 の Tailscale 設定（#237 で導入済み、タグ付けのみ追加）
+
+tailscaled + Tailscale SSH は 2026-07-03 に導入済み。CD 用に必要な残作業:
+
+```bash
+# mr2 上で: WIF に 1.90.1 以上が必要（古ければ apt upgrade）
+tailscale version
+
+# tag:prod を広告（ACL の dst 指定に使う。--ssh は既存設定の維持で必要）
+sudo tailscale up --ssh --advertise-tags=tag:prod
+```
+
+- Tailscale SSH は port 22 を横取りするため、鍵ベース SSH は実 sshd に届かない（既知）
+- CD に必要なのは mr2 のみ（pve は不要）
+
+### 2. Tailscale ACL（管理画面 → Access Controls）
+
+```jsonc
+{
+  "tagOwners": {
+    "tag:ci":   ["autogroup:admin"],
+    "tag:prod": ["autogroup:admin"],
+  },
+  "grants": [
+    // 人間のデバイスは全許可（デフォルトの src "*" から変更。
+    // "*" のままだと tag:ci ノードが pve 等タネット内全部に届いてしまう）
+    {"src": ["autogroup:member"], "dst": ["*"], "ip": ["*"]},
+    // CI ランナーは mr2 の SSH にのみ到達可（Tailscale SSH でも tcp:22 の grant が必要）
+    {"src": ["tag:ci"], "dst": ["tag:prod"], "ip": ["tcp:22"]},
+  ],
+  "ssh": [
+    // 既存: 自分のタグなしデバイスへの SSH（デフォルトルール、残す）
+    {"action": "check", "src": ["autogroup:member"], "dst": ["autogroup:self"],
+     "users": ["autogroup:nonroot", "root"]},
+    // 罠: mr2 は tag:prod を付けると autogroup:self から外れるため、
+    // このルールがないと人間の ssh mr2 が壊れる
+    {"action": "check", "src": ["autogroup:member"], "dst": ["tag:prod"],
+     "users": ["autogroup:nonroot", "root"]},
+    // 鍵レス SSH: tag:ci ノードから mr2 に huji333 としてのみ入れる。
+    // CI は非対話なので必ず "accept"（"check" だとブラウザ承認待ちで詰まる）
+    {"action": "accept", "src": ["tag:ci"], "dst": ["tag:prod"], "users": ["huji333"]},
+  ],
+  "tests": [
+    {"src": "tag:ci", "accept": ["tag:prod:22"]},
+  ],
+}
+```
+
+**適用順序**: ACL を保存してから mr2 で `tailscale up --advertise-tags=tag:prod` を実行
+（tagOwners 未定義のまま advertise するとエラー）。副作用: tag 付け後の mr2 は src として
+許可する grant がないためタネット内の他ノードへ自発接続できない（外向き通信は無影響）。
+
+### 3. Workload identity federation（管理画面）
+
+[KB: workload-identity-federation](https://tailscale.com/kb/1581/workload-identity-federation) に従い
+federated identity client を作成:
+
+- **Issuer**: `https://token.actions.githubusercontent.com`
+- **Subject の条件**: `repo:huji333/portfolio:ref:refs/heads/main`
+  （main の push / main 上での手動 dispatch だけがトークンを取得できる）
+- **Audience**: 任意の文字列（例: `portfolio-deploy`）
+- **Scope**: `auth_keys` (write)、タグは `tag:ci`
+
+発行された client ID と audience を GitHub repo の **Variables**（Settings →
+Secrets and variables → Actions → Variables）に登録:
+
+- `TS_FEDERATED_CLIENT_ID`
+- `TS_AUDIENCE`
+
+どちらも秘密情報ではないので Variables でよい（Secrets に入れる長期トークンは存在しない）。
+
+### 4. GHCR パッケージを public にする
+
+初回の Deploy 実行（build まで成功し deploy で失敗してよい）後、
+`ghcr.io/huji333/portfolio-backend` / `portfolio-frontend` の package settings で
+**Visibility: Public** に変更（public repo のビルド成果物なので秘匿する意味はない）。
+これで mr2 は `docker login` なしで pull できる。
+
+### 5. mr2 側の前提確認
+
+```bash
+# ~/portfolio の remote が匿名 pull できる HTTPS であること（bin/deploy が git pull する）
+git -C ~/portfolio remote set-url origin https://github.com/huji333/portfolio.git
+```
+
+- `.env` の `IMAGE_TAG` は `bin/deploy` が自動で追記・更新する（手動編集不要）
+- GitHub 側の branch protection（main への直 push 禁止 + CI 必須）を有効にすること。
+  「main に push できる = mr2 に SSH できる」構成なので、これが実質の防壁
+
+## 運用
+
+- **通常デプロイ**: PR を main にマージするだけ（backend/frontend/compose に差分があるとき発火）
+- **ロールバック**: Actions → Deploy → Run workflow で `image_tag` に過去の commit SHA を指定
+  （build はスキップされ、そのイメージを再デプロイ。compose ファイルは最新 main のままな点に注意）
+- **緊急時のローカルビルド**: mr2 上で従来通り
+  `docker compose -f docker-compose.prod.yml up -d --build`（`build:` は残してある）
+
+## セキュリティ上の判断メモ（2026-07）
+
+- push 型（Actions → Tailscale SSH）を選択。pull 型（mr2 が GHCR をポーリング）は
+  GitHub→自宅の経路が構成上消える分強いが、月2回程度のデプロイ頻度では
+  Actions 上で成否が見える運用性と migrate の順序制御を優先した
+- GHA の主リスクは「secrets の長期トークンを供給網攻撃で抜かれる」パターン
+  （2025-03 tj-actions 事件等）。本構成は抜かれる長期トークンが存在せず、
+  action は全て commit SHA でピン留めしている
+- fork PR には OIDC トークンも secrets も渡らないため public repo でも安全
+  （deploy は `push: main` と手動 dispatch のみで発火）
+- **この repo に self-hosted runner を置かないこと**（fork PR のコードが
+  自宅 LAN で実行されうる唯一の明確な NG 構成）

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ──────────────────────────────────────────────
+# bin/deploy — GHCR のイメージで本番を更新する（mr2 上で実行）
+#
+# Usage:
+#   bin/deploy <image-tag>   # image-tag = commit SHA（CI が push したタグ）
+#
+# 通常は GitHub Actions (deploy.yml) から Tailscale SSH 経由で呼ばれる。
+# ロールバックは過去の SHA を渡して手動実行でも可。
+# ──────────────────────────────────────────────
+
+TAG="${1:?Usage: bin/deploy <image-tag>}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+COMPOSE=(docker compose -f docker-compose.prod.yml)
+
+echo "[deploy $(date -Iseconds)] start: tag=${TAG}"
+
+# compose ファイル等を最新化（ロールバック時は古いイメージ×最新 compose になる点に注意）
+git pull --ff-only origin main
+
+# IMAGE_TAG は .env に永続化する（compose の変数展開の single source。
+# 以後の手動 `docker compose up -d` も同じタグを使う）
+if grep -q '^IMAGE_TAG=' .env; then
+  sed -i "s|^IMAGE_TAG=.*|IMAGE_TAG=${TAG}|" .env
+else
+  printf '\nIMAGE_TAG=%s\n' "$TAG" >> .env
+fi
+
+echo "[deploy] pulling images"
+"${COMPOSE[@]}" pull backend frontend
+
+echo "[deploy] backing up db"
+bash bin/backup-db
+
+echo "[deploy] running migrations"
+"${COMPOSE[@]}" --profile migrate run --rm migrate
+
+echo "[deploy] restarting services"
+"${COMPOSE[@]}" up -d
+
+echo "[deploy] healthcheck"
+for _ in $(seq 1 30); do
+  if curl -fsS -o /dev/null --max-time 5 https://kakemu.work \
+     && curl -fsS -o /dev/null --max-time 5 https://api.kakemu.work/up; then
+    echo "[deploy $(date -Iseconds)] OK: tag=${TAG}"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "[deploy $(date -Iseconds)] FAILED: healthcheck timed out (tag=${TAG})" >&2
+"${COMPOSE[@]}" ps >&2
+exit 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,8 +7,13 @@
 # Migration: 初回または schema 変更後に一度だけ migrate サービスを実行
 #   docker compose -f docker-compose.prod.yml --profile migrate run --rm migrate
 
+# CD: 通常運用では CI (deploy.yml) が GHCR に push したイメージを IMAGE_TAG で指定して
+# pull する（bin/deploy が .env の IMAGE_TAG を更新）。build: は緊急時のローカルビルド
+# フォールバック（--build 指定時のみ使われる）。
+
 services:
   backend:
+    image: ghcr.io/huji333/portfolio-backend:${IMAGE_TAG:-latest}
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -37,6 +42,7 @@ services:
     restart: unless-stopped
 
   frontend:
+    image: ghcr.io/huji333/portfolio-frontend:${IMAGE_TAG:-latest}
     build:
       context: ./frontend
       dockerfile: Dockerfile
@@ -93,6 +99,8 @@ services:
     restart: unless-stopped
 
   migrate:
+    # backend と同一イメージ（backend の pull で解決されるため個別 pull 不要）
+    image: ghcr.io/huji333/portfolio-backend:${IMAGE_TAG:-latest}
     build:
       context: ./backend
       dockerfile: Dockerfile


### PR DESCRIPTION
## 概要
main への push で GHCR にイメージを push し、Tailscale workload identity federation 経由で mr2 に自動デプロイする。長期 credential はどこにも置かない。

Closes #57

## レビュー優先度
🔴 全文レビュー — 本番デプロイ経路とセキュリティ境界（tailnet ACL 前提）に関わる変更

## 判断・トレードオフ
- **push 型（Actions→Tailscale SSH）** を採用。pull 型（mr2 が GHCR をポーリング）は GitHub→自宅の経路が構成上消える分強いが、月2回程度のデプロイ頻度では Actions 上での成否可視化と migrate の順序制御を優先した
- **認証はすべて短命トークン**: GHCR push = `GITHUB_TOKEN`、tailnet 参加 = GitHub OIDC→WIF、mr2 SSH = Tailscale SSH（鍵レス、ACL で tag:ci→mr2:22 のみ）。secrets には何も入れない
- `NEXT_PUBLIC_*` ビルド引数はクライアント JS に焼き込まれる公開値のため workflow に直書き（repo Variables 化より変更履歴が diff に残る方を取った）
- compose の `build:` は緊急時のローカルビルド用フォールバックとして残置

## 確認
- `bash -n bin/deploy`、`docker compose config`、workflow YAML パースは通過
- **未確認**: 初回デプロイは未実施（マージ後に発火する。GHCR パッケージが private の場合 pull で落ちるため、public 化→再実行の手順が DEPLOY.md にある）
- **未照合**: `NEXT_PUBLIC_CLOUDFRONT_BASE_URL`（deploy.yml 直書き）が mr2 の本番 .env と同値であること

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)