### PR TITLE
fix(cd): deploy 前に mr2 側 checkout を git pull する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,8 @@ jobs:
           tags: tag:ci
 
       - name: Deploy to mr2
+        # git pull を前置: bin/deploy 自体の更新を反映してから実行する
+        # （script 内の pull だけだと script 新規追加/更新時に古いものが走る）
         run: |
           ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
-            huji333@mr2 "~/portfolio/bin/deploy $IMAGE_TAG"
+            huji333@mr2 "git -C ~/portfolio pull --ff-only origin main && ~/portfolio/bin/deploy $IMAGE_TAG"


### PR DESCRIPTION
## 概要
初回 Deploy 実行が exit 127 で失敗（mr2 に bin/deploy がまだ存在しない bootstrap 問題）。SSH コマンドに `git pull --ff-only` を前置し、script 更新が常に実行前に反映されるようにする。

## レビュー優先度
🟢 レビュー不要 — 1行の SSH コマンド修正

## 確認
- 初回実行 (run 28707995080) で build×2 / WIF tailnet 参加 / Tailscale SSH 接続まで成功していることをログで確認済み。失敗はこの bootstrap のみ
- GHCR パッケージは匿名 pull 可（public 継承）を確認済み

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)