### PR TITLE
fix(admin): inline style を admin.css にクラス化（prod CSP で巨大表示になる問題）

### DIFF
--- a/backend/app/assets/stylesheets/admin.css
+++ b/backend/app/assets/stylesheets/admin.css
@@ -1,0 +1,33 @@
+/* 管理画面用スタイル。
+ * prod は CSP 強制 + style-src に unsafe-inline 無しのため、要素の style= 属性は
+ * ブラウザにブロックされる。サイズ・装飾はここのクラスで当てる（inline style 禁止）。 */
+
+.admin-thumb-list {
+  height: 64px;
+  width: auto;
+}
+
+.admin-thumb-show {
+  max-width: 300px;
+}
+
+.admin-form-preview {
+  max-height: 70vh;
+  object-fit: contain;
+}
+
+.admin-form-dropzone {
+  min-height: 320px;
+}
+
+.admin-dropzone {
+  border: 2px dashed #ccc;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+/* progress-bar の初期幅。アップロード進捗は direct_upload_controller が
+ * bar.style.width（CSSOM 代入=CSP 対象外）で更新する。 */
+.admin-progress-bar {
+  width: 0;
+}

--- a/backend/app/views/admin/image_bulk_imports/new.html.haml
+++ b/backend/app/views/admin/image_bulk_imports/new.html.haml
@@ -12,12 +12,12 @@
       - else
         %li.list-group-item.list-group-item-danger ✗ #{result[:filename]} — #{result[:errors].join('、')}
 
-= form_with(url: admin_image_bulk_import_path, scope: :bulk, local: true, multipart: true, data: { controller: "direct-upload" }, style: "border: 2px dashed #ccc; padding: 20px; border-radius: 8px;") do |form|
+= form_with(url: admin_image_bulk_import_path, scope: :bulk, local: true, multipart: true, data: { controller: "direct-upload" }, class: "admin-dropzone") do |form|
   .mb-3
     = form.label :files, '画像ファイル（複数選択可）', class: 'col-form-label fw-bold'
     = form.file_field :files, multiple: true, direct_upload: true, accept: 'image/*', class: 'form-control', data: { direct_upload_target: "input" }
   .progress.d-none.mb-3{ data: { direct_upload_target: "progress" } }
-    .progress-bar.progress-bar-striped.progress-bar-animated{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100", style: "width: 0%" }
+    .progress-bar.progress-bar-striped.progress-bar-animated.admin-progress-bar{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100" }
   .alert.alert-danger.d-none.mb-3{ data: { direct_upload_target: "error" } }
 
   %h3 共通カテゴリ（全画像に適用）

--- a/backend/app/views/admin/images/_form.html.haml
+++ b/backend/app/views/admin/images/_form.html.haml
@@ -7,16 +7,16 @@
 
   .card
     .row.g-0
-      .col-lg-6.d-flex.align-items-center.justify-content-center.bg-body-tertiary.p-3{style: 'min-height: 320px;'}
+      .col-lg-6.d-flex.align-items-center.justify-content-center.bg-body-tertiary.p-3.admin-form-dropzone
         - if image.file.attached?
-          = image_tag image.thumbnail_variant, class: 'img-fluid rounded', style: 'max-height: 70vh; object-fit: contain;', alt: image.title.presence || 'preview'
+          = image_tag image.thumbnail_variant, class: 'img-fluid rounded admin-form-preview', alt: image.title.presence || 'preview'
         - else
           .w-100
             = form.label :file, '画像ファイル', class: 'form-label fw-bold'
             = form.file_field :file, direct_upload: true, class: 'form-control', data: { direct_upload_target: "input", exif_fill_target: "fileInput", action: "change->exif-fill#fileSelected" }
             %div{ data: { exif_fill_target: 'status' } }
             .progress.d-none.mt-2{ data: { direct_upload_target: "progress" } }
-              .progress-bar.progress-bar-striped.progress-bar-animated{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100", style: "width: 0%" }
+              .progress-bar.progress-bar-striped.progress-bar-animated.admin-progress-bar{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100" }
             .alert.alert-danger.d-none.mt-2{ data: { direct_upload_target: "error" } }
 
       .col-lg-6.d-flex.flex-column

--- a/backend/app/views/admin/images/_image_preview.html.haml
+++ b/backend/app/views/admin/images/_image_preview.html.haml
@@ -1,4 +1,4 @@
 - if image.file.attached?
-  = image_tag(image.thumbnail_variant, alt: "#{image.title} preview", style: "height: 64px; width: auto;")
+  = image_tag(image.thumbnail_variant, alt: "#{image.title} preview", class: "admin-thumb-list")
 - else
   %span.text-muted プレビューなし

--- a/backend/app/views/admin/images/show.html.haml
+++ b/backend/app/views/admin/images/show.html.haml
@@ -1,7 +1,7 @@
 %h1 画像詳細
 - if @image.file.attached?
   .mb-3
-    = image_tag @image.thumbnail_variant, class: 'img-fluid img-thumbnail', style: 'max-width: 300px;'
+    = image_tag @image.thumbnail_variant, class: 'img-fluid img-thumbnail admin-thumb-show'
 - else
   %p.text-muted No image attached.
 .row.py-1

--- a/backend/app/views/admin/projects/_form.html.haml
+++ b/backend/app/views/admin/projects/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: project, url: project.new_record? ? admin_projects_path : admin_project_path(project), local: true, multipart: true, data: { controller: "direct-upload" }, style: "border: 2px dashed #ccc; padding: 20px; border-radius: 8px;") do |form|
+= form_with(model: project, url: project.new_record? ? admin_projects_path : admin_project_path(project), local: true, multipart: true, data: { controller: "direct-upload" }, class: "admin-dropzone") do |form|
   - if project.errors.any?
     .alert.alert-danger
       %ul
@@ -26,7 +26,7 @@
       = form.file_field :file, direct_upload: true, class: 'form-control', data: { direct_upload_target: "input" }
     .col-md-9.offset-md-3.mt-2
       .progress.d-none{ data: { direct_upload_target: "progress" } }
-        .progress-bar.progress-bar-striped.progress-bar-animated{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100", style: "width: 0%" }
+        .progress-bar.progress-bar-striped.progress-bar-animated.admin-progress-bar{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100" }
       .alert.alert-danger.d-none.mt-2{ data: { direct_upload_target: "error" } }
       - if project.file.attached?
         %small.text-muted.d-block.mt-2


### PR DESCRIPTION
## 概要
prod だけ CSP enforced + style-src に unsafe-inline 無しで要素の `style=` 属性がブロックされ、管理画面の画像プレビュー等が指定サイズを失って巨大表示になっていた問題を、inline style の全クラス化で修正。

## レビュー優先度
🟡 動作確認のみ — 挙動変更は prod の描画が仕様どおりに戻ることのみ。ロジック変更なし。

## 判断・トレードオフ
- CSP は緩めない方針。`style-src` に `'unsafe-inline'` を足すのではなく、self-host の `admin.css`（`style-src :self` で許可済み）へ寄せた。nonce は `<style>`/`<script>` 要素専用で `style=` 属性には効かないため、属性インラインは今後も使わない。
- progress-bar の進捗更新は `direct_upload_controller.js` の `bar.style.width`（CSSOM 代入＝CSP 対象外）で動くため据え置き。HTML 側の初期 `width:0%` 属性のみクラス化（CSP 違反ノイズの除去）。

## 確認
- 変更した haml 5枚を compile して構文 OK を確認。`app/views` 配下の inline `style=` はゼロ。
- 実描画の目視は未（dev は CSP report-only で元々崩れず、この修正の効果は prod でしか確認できない）。反映には prod イメージ再ビルド（assets precompile）が必要。デプロイ後に一覧が 64px に戻る／フォームのダッシュ枠が復活することを要確認。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)