### PR TITLE
feat(admin): 画像一覧の一括メタデータ付与 + 一括取り込みの共通カメラ・レンズ選択

### DIFF
--- a/backend/app/controllers/admin/image_bulk_imports_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_imports_controller.rb
@@ -1,6 +1,7 @@
 class Admin::ImageBulkImportsController < Admin::Base
+  before_action :set_form_options
+
   def new
-    @categories = Category.order(:name)
     @results = nil
   end
 
@@ -8,16 +9,14 @@ class Admin::ImageBulkImportsController < Admin::Base
   # by the model layer). Failures are isolated per file so one bad frame never
   # aborts the rest of the roll; the result list says exactly which files failed.
   def create
-    @categories = Category.order(:name)
     signed_ids = Array(params.dig(:bulk, :files)).compact_blank
-    category_ids = Array(params.dig(:bulk, :category_ids)).compact_blank
 
     if signed_ids.empty?
       flash.now[:alert] = 'ファイルが選択されていません。'
       return render :new, status: :unprocessable_content
     end
 
-    @results = signed_ids.map { |signed_id| ingest_draft(signed_id, category_ids) }
+    @results = signed_ids.map { |signed_id| ingest_draft(signed_id, shared_attributes) }
     failed = @results.count { |result| result[:image].nil? || !result[:image].persisted? }
 
     if failed.zero?
@@ -31,9 +30,25 @@ class Admin::ImageBulkImportsController < Admin::Base
 
   private
 
-  def ingest_draft(signed_id, category_ids)
+  def set_form_options
+    @categories = Category.order(:name)
+    @cameras = Camera.order(:manufacturer, :name)
+    @lenses = Lens.order(:name)
+  end
+
+  # 全画像に共通で付ける属性。camera/lens は明示指定があれば EXIF より優先される
+  # （モデルの fill_metadata_from_exif は空欄しか埋めないため、渡すだけで成立する）。
+  def shared_attributes
+    {
+      category_ids: Array(params.dig(:bulk, :category_ids)).compact_blank,
+      camera_id: params.dig(:bulk, :camera_id).presence,
+      lens_id: params.dig(:bulk, :lens_id).presence
+    }.compact
+  end
+
+  def ingest_draft(signed_id, shared_attributes)
     blob = ActiveStorage::Blob.find_signed!(signed_id)
-    image = Image.new(file: signed_id, is_published: false, category_ids: category_ids)
+    image = Image.new(file: signed_id, is_published: false, **shared_attributes)
     image.save
     { filename: blob.filename.to_s, image: image, errors: image.errors.full_messages }
   rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound

--- a/backend/app/controllers/admin/image_bulk_updates_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_updates_controller.rb
@@ -1,0 +1,23 @@
+class Admin::ImageBulkUpdatesController < Admin::Base
+  # 画像一覧のチェックボックス選択に対する一括メタデータ付与。空欄の項目は変更しない
+  # （クリアは単体編集で行う）。カテゴリは既存への追加（union）。
+  def update
+    image_ids = Array(params[:image_ids]).compact_blank
+    return redirect_to_images(alert: '画像が選択されていません。') if image_ids.empty?
+
+    camera = Camera.find(params[:camera_id]) if params[:camera_id].present?
+    lens = Lens.find(params[:lens_id]) if params[:lens_id].present?
+    categories = Category.where(id: Array(params[:category_ids]).compact_blank).to_a
+    return redirect_to_images(alert: '適用する項目が選択されていません。') if camera.nil? && lens.nil? && categories.empty?
+
+    images = Image.bulk_assign!(image_ids, camera: camera, lens: lens, categories: categories)
+    redirect_to_images(notice: "#{images.size}枚に一括適用しました。")
+  end
+
+  private
+
+  # 一括操作の戻り先。filter を引き継いで「絞ってから一括付与」のフローを維持する。
+  def redirect_to_images(**flash_options)
+    redirect_to admin_images_path(filter: params[:filter].presence), **flash_options
+  end
+end

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -1,7 +1,7 @@
 class Admin::ImagesController < Admin::Base
   include Admin::ImageCurationFlow
 
-  before_action :set_cameras_and_lenses_and_categories, only: %i[new edit create update]
+  before_action :set_cameras_and_lenses_and_categories, only: %i[index new edit create update]
   before_action :set_image, only: %i[show edit update destroy insert_at]
   before_action :set_adjacent_images, only: %i[edit update]
 

--- a/backend/app/javascript/controllers/bulk_edit_controller.js
+++ b/backend/app/javascript/controllers/bulk_edit_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 画像一覧の一括編集。全選択トグル・選択数の表示・操作バーの表示/非表示だけを
+// 担当し、送信は素のフォーム POST（PATCH bulk_update）に任せる。
+export default class extends Controller {
+  static targets = ["checkbox", "selectAll", "bar", "count", "submit"]
+
+  connect() {
+    this.refresh()
+  }
+
+  toggleAll() {
+    const checked = this.selectAllTarget.checked
+    this.checkboxTargets.forEach((checkbox) => {
+      checkbox.checked = checked
+    })
+    this.refresh()
+  }
+
+  refresh() {
+    const count = this.checkboxTargets.filter((checkbox) => checkbox.checked).length
+    this.barTarget.classList.toggle("d-none", count === 0)
+    this.countTarget.textContent = count
+    this.submitTarget.disabled = count === 0
+    this.selectAllTarget.checked = count > 0 && count === this.checkboxTargets.length
+    this.selectAllTarget.indeterminate = count > 0 && count < this.checkboxTargets.length
+  }
+}

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -56,6 +56,21 @@ class Image < ApplicationRecord
     end
   end
 
+  # 一括メタデータ付与。nil の属性は変更せず、カテゴリは既存への追加（union）。
+  # 部分成功を作らない：ID の欠落や 1 件の失敗で全体をロールバックする（fail-loud）。
+  def self.bulk_assign!(ids, camera: nil, lens: nil, categories: [])
+    images = where(id: ids).to_a
+    raise ActiveRecord::RecordNotFound, 'Some images not found' if images.size != ids.uniq.size
+
+    transaction do
+      images.each do |image|
+        image.update!({ camera: camera, lens: lens }.compact)
+        categories.each { |category| image.image_categories.find_or_create_by!(category: category) }
+      end
+    end
+    images
+  end
+
   def self.filter_by_categories(category_ids)
     return all if category_ids.blank?
 

--- a/backend/app/views/admin/image_bulk_imports/new.html.haml
+++ b/backend/app/views/admin/image_bulk_imports/new.html.haml
@@ -20,7 +20,18 @@
     .progress-bar.progress-bar-striped.progress-bar-animated.admin-progress-bar{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100" }
   .alert.alert-danger.d-none.mb-3{ data: { direct_upload_target: "error" } }
 
-  %h3 共通カテゴリ（全画像に適用）
+  %h3 共通メタデータ（全画像に適用）
+  .row
+    .col-md-6.mb-3
+      = label_tag 'bulk_camera_id', 'カメラ', class: 'form-label fw-bold'
+      = select_tag 'bulk[camera_id]', options_from_collection_for_select(@cameras, :id, :name),
+        include_blank: 'EXIF から自動判定', id: 'bulk_camera_id', class: 'form-select'
+    .col-md-6.mb-3
+      = label_tag 'bulk_lens_id', 'レンズ', class: 'form-label fw-bold'
+      = select_tag 'bulk[lens_id]', options_from_collection_for_select(@lenses, :id, :name),
+        include_blank: 'EXIF から自動判定', id: 'bulk_lens_id', class: 'form-select'
+  %small.text-muted.d-block.mb-2 カメラ・レンズを選ぶと EXIF より優先して全画像に付きます。未選択なら EXIF から自動で入ります。
+  %span.form-label.fw-bold.d-block カテゴリ
   - @categories.each do |category|
     .form-check
       = check_box_tag 'bulk[category_ids][]', category.id, false, id: "bulk_category_#{category.id}", class: 'form-check-input'

--- a/backend/app/views/admin/images/_image_row.html.haml
+++ b/backend/app/views/admin/images/_image_row.html.haml
@@ -1,5 +1,9 @@
 %tr.cursor-pointer{"data-image-id": image.id}
   %td
+    = check_box_tag 'image_ids[]', image.id, false,
+      id: "select_image_#{image.id}", class: 'form-check-input', "aria-label": "選択",
+      data: { bulk_edit_target: "checkbox", action: "bulk-edit#refresh" }
+  %td
     = link_to edit_admin_image_path(image), class: 'd-block' do
       = render 'admin/images/image_preview', image: image
   %td

--- a/backend/app/views/admin/images/index.html.haml
+++ b/backend/app/views/admin/images/index.html.haml
@@ -14,13 +14,44 @@
       = "未編集の下書き #{@uncurated_count} 枚を表示。"
       = link_to '未編集のみ表示', admin_images_path(filter: "uncurated")
 
-.table-responsive
-  %table.table.table-hover
-    %thead
-      %tr
-        %th プレビュー
-        %th タイトル
-        %th 状態
-    %tbody
-      - @images.each do |image|
-        = render 'image_row', image: image
+= form_with(url: admin_image_bulk_update_path, method: :patch, local: true, data: { controller: "bulk-edit" }) do
+  = hidden_field_tag :filter, params[:filter]
+  .table-responsive
+    %table.table.table-hover.align-middle
+      %thead
+        %tr
+          %th
+            %input.form-check-input{ type: "checkbox", "aria-label": "全選択",
+              data: { bulk_edit_target: "selectAll", action: "bulk-edit#toggleAll" } }
+          %th プレビュー
+          %th タイトル
+          %th 状態
+      %tbody
+        - @images.each do |image|
+          = render 'image_row', image: image
+
+  -# 選択中のみ表示される一括操作バー。空欄の項目は変更されない（クリアは単体編集で）。
+  .card.position-sticky.bottom-0.mb-3.shadow.d-none{ data: { bulk_edit_target: "bar" } }
+    .card-body.py-2
+      .d-flex.flex-wrap.align-items-center.gap-3
+        .fw-bold.text-nowrap
+          %span{ data: { bulk_edit_target: "count" } } 0
+          枚を選択中
+        .d-flex.align-items-center.gap-1
+          = label_tag :camera_id, 'カメラ', class: 'col-form-label col-form-label-sm text-nowrap'
+          = select_tag :camera_id, options_from_collection_for_select(@cameras, :id, :name),
+            include_blank: '変更しない', class: 'form-select form-select-sm'
+        .d-flex.align-items-center.gap-1
+          = label_tag :lens_id, 'レンズ', class: 'col-form-label col-form-label-sm text-nowrap'
+          = select_tag :lens_id, options_from_collection_for_select(@lenses, :id, :name),
+            include_blank: '変更しない', class: 'form-select form-select-sm'
+        - if @categories.any?
+          .d-flex.align-items-center.gap-2
+            %span.col-form-label.col-form-label-sm.text-nowrap カテゴリ追加
+            - @categories.each do |category|
+              .form-check.form-check-inline.mb-0
+                = check_box_tag 'category_ids[]', category.id, false,
+                  id: "bulk_category_#{category.id}", class: 'form-check-input'
+                = label_tag "bulk_category_#{category.id}", category.name, class: 'form-check-label'
+        = submit_tag '選択した画像に適用', class: 'btn btn-primary btn-sm ms-auto',
+          data: { bulk_edit_target: "submit" }

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,15 +11,14 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: 'index#index'
     resources :images do
-      member do
-        post :insert_at
-      end
+      post :insert_at, on: :member
       collection do
         get :arrange
         post :extract_exif
       end
     end
     resource :image_bulk_import, only: %i[new create]
+    resource :image_bulk_update, only: %i[update]
     get 'gear', to: 'gear#index'
     resources :cameras, except: %i[index show]
     resources :lenses, except: %i[index show]

--- a/backend/spec/requests/admin/image_bulk_imports_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_imports_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
       end
     end
 
+    it 'applies an explicitly chosen shared camera/lens over EXIF' do
+      camera = create(:camera)
+      lens = create(:lens)
+
+      post '/admin/image_bulk_import',
+           params: { bulk: { files: [upload_fixture_blob.signed_id],
+                             camera_id: camera.id, lens_id: lens.id } }
+
+      expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
+      draft = Image.order(:id).last
+      # EXIF（SONY ILCE-7CM2）ではなく手動選択が勝つ。taken_at は EXIF から入る
+      expect(draft.camera).to eq(camera)
+      expect(draft.lens).to eq(lens)
+      expect(draft.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
+    end
+
     it 'isolates failures per file: valid files are ingested, invalid ones reported' do
       signed_ids = [upload_fixture_blob.signed_id, 'bogus-signed-id']
 

--- a/backend/spec/requests/admin/image_bulk_updates_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_updates_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::ImageBulkUpdates', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user, :admin) }
+  let!(:image1) { create(:image, title: 'Test Image 1', row_order: 100) }
+  let!(:image2) { create(:image, title: 'Test Image 2', row_order: 200) }
+  let!(:image3) { create(:image, title: 'Test Image 3', row_order: 300) }
+  let(:camera) { create(:camera) }
+  let(:lens) { create(:lens) }
+  let(:category) { create(:category) }
+
+  before { sign_in user }
+
+  describe 'PATCH /admin/image_bulk_update' do
+    it 'assigns camera, lens, and categories to the selected images only' do
+      patch '/admin/image_bulk_update',
+            params: { image_ids: [image1.id, image2.id],
+                      camera_id: camera.id, lens_id: lens.id, category_ids: [category.id] }
+
+      expect(response).to redirect_to(admin_images_path)
+      expect(flash[:notice]).to include('2枚')
+      expect(image1.reload).to have_attributes(camera: camera, lens: lens)
+      expect(image1.categories).to eq([category])
+      expect(image2.reload.camera).to eq(camera)
+      # 未選択の画像は触らない（factory が付けた元のカメラのまま）
+      expect(image3.reload.camera).not_to eq(camera)
+    end
+
+    it 'leaves blank fields untouched（空欄 = 変更しない）' do
+      original_lens = create(:lens)
+      image1.update!(lens: original_lens)
+
+      patch '/admin/image_bulk_update', params: { image_ids: [image1.id], camera_id: camera.id }
+
+      expect(image1.reload.camera).to eq(camera)
+      expect(image1.lens).to eq(original_lens)
+    end
+
+    it 'adds categories to existing ones without duplicates（union）' do
+      existing = create(:category)
+      image1.categories << existing
+      image1.categories << category
+
+      expect do
+        patch '/admin/image_bulk_update',
+              params: { image_ids: [image1.id], category_ids: [category.id] }
+      end.not_to change(ImageCategory, :count)
+
+      expect(image1.reload.categories).to contain_exactly(existing, category)
+    end
+
+    it 'preserves the uncurated filter on redirect' do
+      patch '/admin/image_bulk_update',
+            params: { image_ids: [image1.id], camera_id: camera.id, filter: 'uncurated' }
+
+      expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
+    end
+
+    it 'rejects an empty selection with an alert' do
+      patch '/admin/image_bulk_update', params: { camera_id: camera.id }
+
+      expect(response).to redirect_to(admin_images_path)
+      expect(flash[:alert]).to include('画像が選択されていません')
+    end
+
+    it 'rejects a submission with nothing to apply' do
+      expect do
+        patch '/admin/image_bulk_update', params: { image_ids: [image1.id] }
+      end.not_to(change { image1.reload.camera_id })
+
+      expect(response).to redirect_to(admin_images_path)
+      expect(flash[:alert]).to include('適用する項目')
+    end
+
+    it 'fails loudly when an unknown image id is included' do
+      expect do
+        patch '/admin/image_bulk_update',
+              params: { image_ids: [image1.id, 0], camera_id: camera.id }
+      end.not_to(change { image1.reload.camera_id })
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe 'Admin::Images', type: :request do
       expect(response.body).to include('未編集の下書き 1 枚を表示')
     end
 
+    it 'renders the bulk edit form with per-row checkboxes' do
+      get '/admin/images'
+
+      expect(response.body).to include('bulk_update')
+      expect(response.body).to include("select_image_#{image1.id}")
+      expect(response.body).to include('選択した画像に適用')
+    end
+
     it 'filters to uncurated drafts only' do
       draft = create(:image, :draft, row_order: 500)
 


### PR DESCRIPTION
## 概要
画像一覧にチェックボックス複数選択と一括操作バーを追加し、カメラ・レンズ・カテゴリを1回の操作で付与できるようにする。あわせて一括取り込みフォームにも共通カメラ・レンズ選択を追加。

Closes #261

## レビュー優先度
🔴 全文レビュー — 新機能（一括更新エンドポイント + モデルロジック）

## 判断・トレードオフ
- **空欄 = 変更しない / カテゴリは union（追加）**: カメラだけ付けたいときにレンズが消える事故を防ぐ。クリアや置換は単体編集で足りる（issue コメントで確定済み）
- **専用コントローラ `Admin::ImageBulkUpdatesController` に分離**: images_controller に置くと rubocop Metrics（ClassLength/AbcSize）超過。既存の `ImageBulkImportsController` と同じ分離流儀に揃えた。実体は `Image.bulk_assign!`（transaction + `update!` / `find_or_create_by!` で部分成功を作らない fail-loud。未知 ID 混入は 404）
- **一括取り込みの共通カメラ・レンズは EXIF より優先**: `fill_metadata_from_exif` が「空欄しか埋めない（human input wins）」設計のため、`Image.new` に渡すだけで優先関係が成立。優先ロジックの新設なし。未選択なら従来どおり EXIF 自動
- **JS は表示制御のみ**: Stimulus `bulk_edit_controller` は全選択・選択数・バー表示切替・0件時 submit 無効だけを担当し、送信は素のフォーム PATCH（issue の「JS フレームワーク不要」方針）

## 確認
- rspec フル 135 examples, 0 failures / rubocop 71 files, no offenses（docker compose exec backend）
- localhost で手動確認済み: 一覧で複数選択 → バー表示 → 一括適用、`filter=uncurated` との併用とフィルタ維持、一括取り込みのカメラ・レンズ select

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)