### PR TITLE
feat(backend): 添付ファイル後処理を Solid Queue で非同期化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# 開発環境（Mac ローカル + Traefik）の入口。本番系の操作は bin/ を参照
+.PHONY: up down build logs ps migrate console urls
+
+up: ## 開発環境を起動して URL を表示
+	docker compose up -d
+	@$(MAKE) --no-print-directory urls
+
+down: ## 開発環境を停止
+	docker compose down
+
+build: ## イメージを再ビルド（依存や Dockerfile を変えたとき）
+	docker compose build
+
+logs: ## 全サービスのログを follow（Ctrl-C で抜けても環境は生きたまま）
+	docker compose logs -f
+
+ps: ## 起動状態を確認
+	docker compose ps
+
+migrate: ## DB マイグレーションを実行
+	docker compose run --rm migrate
+
+console: ## Rails コンソール
+	docker compose exec backend rails console
+
+urls:
+	@echo "frontend:  http://portfolio.localhost"
+	@echo "backend:   http://api.portfolio.localhost"
+	@echo "traefik:   http://traefik.localhost  (ルーティング一覧)"

--- a/backend/.env.development.sample
+++ b/backend/.env.development.sample
@@ -2,9 +2,10 @@ FRONTEND_ORIGIN="http://localhost:3001"
 
 # AWS / S3
 # Direct Upload を使用するため、S3 バケットに CORS 設定が必要です。
-# 例: AllowedOrigins=["http://localhost:3100"], AllowedMethods=["PUT"],
-#     AllowedHeaders=["Content-Type","Content-MD5","Content-Disposition"],
-#     ExposeHeaders=["ETag"]
+# admin をどのオリジンで開くかに合わせて AllowedOrigins を設定すること。
+# Traefik 経由(make up)なら http://api.portfolio.localhost、直ポートなら http://localhost:3000。
+# 例: AllowedOrigins=["http://api.portfolio.localhost","http://portfolio.localhost","http://localhost:3000"],
+#     AllowedMethods=["GET","POST","PUT","DELETE","HEAD"], AllowedHeaders=["*"], ExposeHeaders=["ETag"]
 AWS_ACCESS_KEY_ID=your_dev_access_key
 AWS_SECRET_ACCESS_KEY=your_dev_secret_key
 AWS_REGION=ap-northeast-1

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -55,6 +55,11 @@ gem "ruby-vips", "~> 2.2"
 
 gem "aws-sdk-s3", "~> 1.226"
 
+# DB-backed Active Job backend (Rails 8 default)。再起動を跨いでジョブが消えない
+gem "solid_queue"
+# /admin 配下のジョブダッシュボード。失敗ジョブの閲覧・リトライ（fail-loud）
+gem "mission_control-jobs"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
@@ -140,6 +142,9 @@ GEM
     ffi (1.17.4-x86-linux-gnu)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
+    fugit (1.12.3)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     haml (7.2.0)
@@ -184,6 +189,16 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.8.1)
     net-imap (0.6.3)
       date
@@ -227,6 +242,7 @@ GEM
       stringio
     puma (8.0.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-cors (3.0.0)
@@ -335,6 +351,13 @@ GEM
     securerandom (0.4.1)
     shoulda-matchers (8.0.1)
       activesupport (>= 7.2)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -393,6 +416,7 @@ DEPENDENCIES
   haml-rails
   image_processing (~> 2.0)
   importmap-rails
+  mission_control-jobs
   pg (~> 1.5)
   puma (>= 6.4)
   rack-cors
@@ -405,6 +429,7 @@ DEPENDENCIES
   rubocop-rspec
   ruby-vips (~> 2.2)
   shoulda-matchers
+  solid_queue
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/backend/app/controllers/admin/image_bulk_imports_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_imports_controller.rb
@@ -5,9 +5,10 @@ class Admin::ImageBulkImportsController < Admin::Base
     @results = nil
   end
 
-  # Ingests each direct-uploaded blob as a draft Image (EXIF metadata is filled
-  # by the model layer). Failures are isolated per file so one bad frame never
-  # aborts the rest of the roll; the result list says exactly which files failed.
+  # Ingests each direct-uploaded blob as a draft Image. Record creation is
+  # DB-only and fast; EXIF fill / analyze / variants run in ProcessAttachedFileJob
+  # so the request never downloads from S3. Failures are isolated per file so one
+  # bad frame never aborts the rest of the roll; the result list says which failed.
   def create
     signed_ids = Array(params.dig(:bulk, :files)).compact_blank
 
@@ -21,7 +22,8 @@ class Admin::ImageBulkImportsController < Admin::Base
 
     if failed.zero?
       redirect_to admin_images_path(filter: "uncurated"),
-                  notice: "#{@results.size}枚を下書きとして取り込みました。1枚ずつタイトルを付けて公開してください。"
+                  notice: "#{@results.size}枚を下書きとして取り込みました。EXIF・サムネイルはバックグラウンドで処理されます。" \
+                          "1枚ずつタイトルを付けて公開してください。"
     else
       flash.now[:alert] = "#{failed}枚の取り込みに失敗しました（#{@results.size - failed}枚は成功）。"
       render :new, status: :unprocessable_content

--- a/backend/app/jobs/application_job.rb
+++ b/backend/app/jobs/application_job.rb
@@ -1,0 +1,4 @@
+class ApplicationJob < ActiveJob::Base
+  # ジョブ実行前にレコードが削除されていたら何もしない
+  discard_on ActiveJob::DeserializationError
+end

--- a/backend/app/jobs/process_attached_file_job.rb
+++ b/backend/app/jobs/process_attached_file_job.rb
@@ -1,0 +1,17 @@
+# CdnAttachedFile を include するモデル（Image / Project）の添付ファイル後処理。
+# analyze と variant 生成を先に済ませてから EXIF 補完の save を行う——この順序で
+# save 時の after_commit 再エンキュー判定（attached_file_needs_processing?）が
+# false になり、ジョブの連鎖が止まる。
+class ProcessAttachedFileJob < ApplicationJob
+  queue_as :default
+
+  # io attach（rake/runner/フォーム）では after_commit のエンキューが S3 アップロード
+  # 完了より先に走りうる（callback 定義順の race）。transient なので有限リトライし、
+  # 使い切ったら fail-loud（failed executions に残る）。
+  retry_on ActiveStorage::FileNotFoundError, wait: :polynomially_longer, attempts: 5
+
+  def perform(record)
+    record.process_attached_file!
+    record.fill_exif_metadata! if record.respond_to?(:fill_exif_metadata!)
+  end
+end

--- a/backend/app/jobs/process_attached_file_job.rb
+++ b/backend/app/jobs/process_attached_file_job.rb
@@ -1,7 +1,6 @@
 # CdnAttachedFile を include するモデル（Image / Project）の添付ファイル後処理。
-# analyze と variant 生成を先に済ませてから EXIF 補完の save を行う——この順序で
-# save 時の after_commit 再エンキュー判定（attached_file_needs_processing?）が
-# false になり、ジョブの連鎖が止まる。
+# analyze・variant 生成・モデル固有の後処理（after_attached_file_processed）までを
+# process_attached_file! が順序込みで担う（順序保証の詳細は concern 側に集約）。
 class ProcessAttachedFileJob < ApplicationJob
   queue_as :default
 
@@ -12,6 +11,5 @@ class ProcessAttachedFileJob < ApplicationJob
 
   def perform(record)
     record.process_attached_file!
-    record.fill_exif_metadata! if record.respond_to?(:fill_exif_metadata!)
   end
 end

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -15,8 +15,13 @@ module CdnAttachedFile
     return unless file.attached?
 
     file.analyze unless file.analyzed?
-    [thumbnail_limit, display_limit].each { |limit| ensure_variant_processed(variant_for(limit)) }
+    variant_limits.each { |limit| ensure_variant_processed(variant_for(limit)) }
+    after_attached_file_processed
   end
+
+  # variant 生成後・同一ジョブ内で呼ばれるモデル固有の後処理フック（デフォルト no-op）。
+  # variants-before-save の順序保証はここに集約する（Image は EXIF 補完を差し込む）。
+  def after_attached_file_processed; end
 
   def file_url
     return unless file.attached?
@@ -52,6 +57,9 @@ module CdnAttachedFile
   def thumbnail_limit = self.class::THUMBNAIL_LIMIT
   def display_limit = self.class::DISPLAY_LIMIT
 
+  # 後処理・再エンキュー判定の両方が参照する variant サイズの単一ソース。
+  def variant_limits = [thumbnail_limit, display_limit]
+
   def enqueue_attached_file_processing
     return unless attached_file_needs_processing?
 
@@ -64,7 +72,7 @@ module CdnAttachedFile
     return false unless file.attached?
 
     !file.analyzed? ||
-      [thumbnail_limit, display_limit].any? { |limit| !variant_generated?(variant_for(limit)) }
+      variant_limits.any? { |limit| !variant_generated?(variant_for(limit)) }
   end
 
   def log_reference = "#{self.class.name.underscore} #{id}"

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -4,8 +4,18 @@ module CdnAttachedFile
   class MissingCdnBaseUrlError < StandardError; end
 
   included do
-    after_commit :analyze_attached_file, on: %i[create update]
-    after_commit :warm_variants, on: %i[create update]
+    # analyze / variant 生成は S3 ダウンロードを伴うためリクエスト内では行わず、
+    # ジョブに退避する（大量一括取込でのタイムアウト回避）。
+    after_commit :enqueue_attached_file_processing, on: %i[create update]
+  end
+
+  # ProcessAttachedFileJob から呼ばれる。リクエスト経路の variant_url と違い
+  # rescue しない（fail-loud）：失敗は Solid Queue の failed executions に残る。
+  def process_attached_file!
+    return unless file.attached?
+
+    file.analyze unless file.analyzed?
+    [thumbnail_limit, display_limit].each { |limit| ensure_variant_processed(variant_for(limit)) }
   end
 
   def file_url
@@ -42,38 +52,22 @@ module CdnAttachedFile
   def thumbnail_limit = self.class::THUMBNAIL_LIMIT
   def display_limit = self.class::DISPLAY_LIMIT
 
-  def analyze_attached_file
-    return unless file.attached?
-    return if file.analyzed?
+  def enqueue_attached_file_processing
+    return unless attached_file_needs_processing?
 
-    file.analyze
-  rescue ActiveStorage::FileNotFoundError => e
-    log_file_not_found(:analyze_attached_file, e)
-  rescue StandardError => e
-    Rails.logger.error "analyze_attached_file failed (#{log_reference}): #{e.class} #{e.message}"
+    ProcessAttachedFileJob.perform_later(self)
   end
 
-  def warm_variants
-    return unless file.attached?
+  # 導出で判定する（処理状態カラムは持たない）。analyze 済み・variant 生成済みなら
+  # 保存しても再エンキューされず、ジョブ内の save で連鎖が止まる。
+  def attached_file_needs_processing?
+    return false unless file.attached?
 
-    [thumbnail_limit, display_limit].each do |limit|
-      variant = variant_for(limit)
-      ensure_variant_processed(variant) if variant
-    end
-  rescue ActiveStorage::FileNotFoundError => e
-    log_file_not_found(:warm_variants, e)
-  rescue LoadError => e
-    Rails.logger.warn "variant warm skipped (#{log_reference}): #{e.message}"
-  rescue StandardError => e
-    Rails.logger.error "variant warm error (#{log_reference}): #{e.full_message}"
+    !file.analyzed? ||
+      [thumbnail_limit, display_limit].any? { |limit| !variant_generated?(variant_for(limit)) }
   end
 
   def log_reference = "#{self.class.name.underscore} #{id}"
-
-  def log_file_not_found(method, err)
-    Rails.logger.error "#{method} failed (#{log_reference}): " \
-                       "blob exists but file not in storage. #{err.class}: #{err.message}"
-  end
 
   def build_cdn_url(key)
     (base = cdn_base_url) ? "#{base}/#{key}" : nil

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -30,14 +30,19 @@ class Image < ApplicationRecord
 
   validate :taken_at_is_in_the_past
 
-  before_validation :fill_metadata_from_exif, on: :create
-
   def category_ids=(ids)
     super(Array(ids).compact_blank)
   end
 
   def publishable?
     PUBLISH_REQUIREMENTS.all? { |attr| public_send(attr).present? }
+  end
+
+  # ProcessAttachedFileJob から呼ばれる。EXIF 抽出は S3 フルダウンロードを伴うため
+  # リクエスト内（旧: before_validation on: :create）では行わない。
+  def fill_exif_metadata!
+    fill_metadata_from_exif
+    save! if changed?
   end
 
   # 並び替え画面は公開画像のみを表示するため、ドロップ位置は「公開リスト内の index」で

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -38,8 +38,13 @@ class Image < ApplicationRecord
     PUBLISH_REQUIREMENTS.all? { |attr| public_send(attr).present? }
   end
 
-  # ProcessAttachedFileJob から呼ばれる。EXIF 抽出は S3 フルダウンロードを伴うため
-  # リクエスト内（旧: before_validation on: :create）では行わない。
+  # variant 生成後に CdnAttachedFile#process_attached_file! から呼ばれる後処理フック。
+  # EXIF 抽出は S3 フルダウンロードを伴うためリクエスト内では行わずここ（ジョブ内）で実行する。
+  def after_attached_file_processed
+    fill_exif_metadata!
+  end
+
+  # EXIF 補完（旧: before_validation on: :create）。フック経由のほか spec からも直接叩く。
   def fill_exif_metadata!
     fill_metadata_from_exif
     save! if changed?

--- a/backend/app/views/admin/index/index.html.haml
+++ b/backend/app/views/admin/index/index.html.haml
@@ -42,3 +42,6 @@
         .card-body
           %h5.card-title プロジェクト
           %p.card-text.text-muted.mb-0 まとまり単位の展示
+
+  .mt-4
+    = link_to 'ジョブダッシュボード（取り込み処理の失敗はここに残る）', mission_control_jobs_path, class: 'text-muted'

--- a/backend/bin/jobs
+++ b/backend/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -17,6 +17,11 @@ module Backend
     config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths << Rails.root.join("app/models/concerns")
 
+    # ジョブダッシュボード（/admin/jobs）。認証は Admin::Base に委譲し、
+    # gem 既定の HTTP Basic 認証は使わない。
+    config.mission_control.jobs.base_controller_class = "Admin::Base"
+    config.mission_control.jobs.http_basic_auth_enabled = false
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -60,6 +60,9 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # 本番と同じ実行経路を dev でも踏む（:async だと再起動揮発・挙動差が隠れる）
+  config.active_job.queue_adapter = :solid_queue
+
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -65,9 +65,9 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "backend_production"
+  # Solid Queue はメイン DB に同居（connects_to は設定しない）。
+  # ワーカーは Puma 内で動かす（puma.rb の plugin :solid_queue、SOLID_QUEUE_IN_PUMA で有効化）。
+  config.active_job.queue_adapter = :solid_queue
 
   config.action_mailer.perform_caching = false
 

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -47,3 +47,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+# Solid Queue のワーカーを Puma プロセス内で動かす（別コンテナ不要の最小構成）。
+# 負荷が問題になったら env を外して worker service に分離する。
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]

--- a/backend/config/queue.yml
+++ b/backend/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/backend/config/recurring.yml
+++ b/backend/config/recurring.yml
@@ -1,0 +1,15 @@
+# examples:
+#   periodic_cleanup:
+#     class: CleanSoftDeletedRecordsJob
+#     queue: background
+#     args: [ 1000, { batch_size: 500 } ]
+#     schedule: every hour
+#   periodic_cleanup_with_command:
+#     command: "SoftDeletedRecord.due.delete_all"
+#     priority: 2
+#     schedule: at 5am every day
+
+production:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
     resources :categories
     resources :projects
   end
+  # ジョブダッシュボード（認証は Admin::Base 経由、config/application.rb 参照）
+  mount MissionControl::Jobs::Engine, at: "/admin/jobs"
   namespace :api do
     resources :images, only: %i[index]
     resources :categories, only: %i[index]

--- a/backend/db/migrate/20260708030000_create_solid_queue_tables.rb
+++ b/backend/db/migrate/20260708030000_create_solid_queue_tables.rb
@@ -1,0 +1,132 @@
+class CreateSolidQueueTables < ActiveRecord::Migration[8.1]
+  # Solid Queue はメイン DB に同居させる（installer 既定の separate queue DB は不採用。
+  # 規模が小さく、バックアップ・運用を一本化するため）。solid_queue:install が生成する
+  # db/queue_schema.rb の内容を通常 migration に変換したもの。
+  def change
+    create_table :solid_queue_blocked_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+      t.index %i[concurrency_key priority job_id], name: "index_solid_queue_blocked_executions_for_release"
+      t.index %i[expires_at concurrency_key], name: "index_solid_queue_blocked_executions_for_maintenance"
+      t.index :job_id, unique: true
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.bigint :job_id, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+      t.index :job_id, unique: true
+      t.index %i[process_id job_id]
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.bigint :job_id, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+      t.index :job_id, unique: true
+    end
+
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.string :concurrency_key
+      t.timestamps
+      t.index :active_job_id
+      t.index :class_name
+      t.index :finished_at
+      t.index %i[queue_name finished_at], name: "index_solid_queue_jobs_for_filtering"
+      t.index %i[scheduled_at finished_at], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false
+      t.datetime :created_at, null: false
+      t.index :queue_name, unique: true
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.bigint :supervisor_id
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+      t.datetime :created_at, null: false
+      t.string :name, null: false
+      t.index :last_heartbeat_at
+      t.index %i[name supervisor_id], unique: true
+      t.index :supervisor_id
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :created_at, null: false
+      t.index :job_id, unique: true
+      t.index %i[priority job_id], name: "index_solid_queue_poll_all"
+      t.index %i[queue_name priority job_id], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_recurring_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+      t.index :job_id, unique: true
+      t.index %i[task_key run_at], unique: true,
+                                   name: "index_solid_queue_recurring_executions_on_task_key_and_run_at"
+    end
+
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, default: true, null: false
+      t.text :description
+      t.timestamps
+      t.index :key, unique: true
+      t.index :static
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+      t.datetime :created_at, null: false
+      t.index :job_id, unique: true
+      t.index %i[scheduled_at priority job_id], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false
+      t.timestamps
+      t.index :expires_at
+      t.index %i[key value]
+      t.index :key, unique: true
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_08_030000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -118,6 +118,127 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_000000) do
     t.index ["article_id"], name: "index_publishments_on_article_id"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.string "concurrency_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.bigint "job_id", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "active_job_id"
+    t.text "arguments"
+    t.string "class_name", null: false
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "queue_name", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.text "metadata"
+    t.string "name", null: false
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.text "arguments"
+    t.string "class_name"
+    t.string "command", limit: 2048
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -138,4 +259,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_000000) do
   add_foreign_key "images", "cameras"
   add_foreign_key "images", "lenses"
   add_foreign_key "publishments", "articles"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/backend/spec/jobs/process_attached_file_job_spec.rb
+++ b/backend/spec/jobs/process_attached_file_job_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe ProcessAttachedFileJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe 'enqueue wiring (CdnAttachedFile)' do
+    it 'enqueues on image create' do
+      expect { create(:image) }.to have_enqueued_job(described_class)
+    end
+
+    it 'does not re-enqueue on save once the file is processed' do
+      image = create(:image)
+      perform_enqueued_jobs
+
+      expect { image.reload.update!(title: 'renamed') }.not_to have_enqueued_job(described_class)
+    end
+  end
+
+  describe '#perform' do
+    it 'analyzes the file, generates variants, and fills EXIF metadata' do
+      image = create(:image, :draft)
+      perform_enqueued_jobs
+
+      image.reload
+      expect(image.file).to be_analyzed
+      expect(image.file.metadata).to include('width', 'height')
+      expect(image.thumbnail_variant.image).to be_attached
+      expect(image.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
+      expect(image.taken_at).to be_present
+    end
+
+    it 'processes records without EXIF support (Project)' do
+      project = build(:project)
+      project.file = Rack::Test::UploadedFile.new(
+        Rails.root.join('spec/fixtures/files/test_image.jpg'), 'image/jpeg'
+      )
+      project.save!
+      perform_enqueued_jobs
+
+      expect(project.reload.file).to be_analyzed
+    end
+
+    # io attach 経路ではエンキューが S3 アップロード完了より先に走りうる（race）ため
+    # FileNotFoundError はリトライする。上限到達後の再 raise（fail-loud → failed
+    # executions に残る）は retry_on の framework 保証なのでここでは検証しない。
+    it 'retries when the blob is not yet in storage' do
+      image = create(:image)
+      allow(image).to receive(:process_attached_file!).and_raise(ActiveStorage::FileNotFoundError)
+      clear_enqueued_jobs
+
+      expect { described_class.perform_now(image) }.to have_enqueued_job(described_class)
+    end
+  end
+end

--- a/backend/spec/models/image_spec.rb
+++ b/backend/spec/models/image_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe Image, type: :model do
   let(:image) { build(:image) }
 
   describe 'validations' do
-    # Isolate validation behavior from the EXIF auto-fill hook (tested separately
-    # below) — otherwise the fixture's real EXIF would refill a blanked taken_at.
-    before { allow(ExifExtractor).to receive(:from_blob).and_return(ExifExtractor::EMPTY) }
-
     context 'file' do
       it 'should be valid with file' do
         image.file = Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/test_image.jpg"), 'image/jpeg')
@@ -133,7 +129,9 @@ RSpec.describe Image, type: :model do
     end
   end
 
-  describe 'EXIF metadata auto-fill on create' do
+  # EXIF 補完はリクエスト内では走らず ProcessAttachedFileJob から呼ばれる
+  # （エンキューの配線はジョブ側の spec で検証）。
+  describe '#fill_exif_metadata!' do
     let(:exif_blob) do
       ActiveStorage::Blob.create_and_upload!(
         io: Rails.root.join('spec/fixtures/files/test_image.jpg').open,
@@ -143,6 +141,7 @@ RSpec.describe Image, type: :model do
 
     it 'fills taken_at, camera and lens for a draft created without them' do
       image = Image.create!(file: exif_blob.signed_id, is_published: false)
+      image.fill_exif_metadata!
 
       expect(image.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
       expect(image.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
@@ -156,19 +155,21 @@ RSpec.describe Image, type: :model do
 
       image = Image.create!(file: exif_blob.signed_id, is_published: false,
                             taken_at: taken_at, camera: camera, lens: lens)
+      image.fill_exif_metadata!
 
       expect(image.taken_at).to eq(taken_at)
       expect(image.camera).to eq(camera)
       expect(image.lens).to eq(lens)
     end
 
-    it 'still saves a draft when the file has no EXIF (fail-open)' do
+    it 'keeps the draft intact when the file has no EXIF (fail-open)' do
       blank_blob = ActiveStorage::Blob.create_and_upload!(
         io: StringIO.new(Vips::Image.black(4, 4).write_to_buffer('.jpg')),
         filename: 'blank.jpg', content_type: 'image/jpeg'
       )
 
       image = Image.create!(file: blank_blob.signed_id, is_published: false)
+      image.fill_exif_metadata!
 
       expect(image).to be_persisted
       expect(image.taken_at).to be_nil

--- a/backend/spec/requests/admin/image_bulk_imports_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_imports_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Admin::ImageBulkImports', type: :request do
   include Devise::Test::IntegrationHelpers
+  include ActiveJob::TestHelper
 
   let(:user) { create(:user, :admin) }
 
@@ -25,7 +26,7 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
   end
 
   describe 'POST /admin/image_bulk_import' do
-    it 'creates a draft per file with EXIF metadata and shared categories' do
+    it 'creates a draft per file with shared categories; EXIF fills after the job runs' do
       category = create(:category)
       signed_ids = [upload_fixture_blob.signed_id, upload_fixture_blob.signed_id]
 
@@ -36,13 +37,21 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
 
       expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
 
+      # リクエスト内では S3 ダウンロードを伴う処理をしない（EXIF はジョブで補完）
       drafts = Image.order(:id).last(2)
       drafts.each do |draft|
         expect(draft.is_published).to be(false)
         expect(draft.title).to be_nil
+        expect(draft.taken_at).to be_nil
+        expect(draft.categories).to eq([category])
+      end
+
+      perform_enqueued_jobs
+
+      drafts.each(&:reload)
+      drafts.each do |draft|
         expect(draft.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
         expect(draft.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
-        expect(draft.categories).to eq([category])
       end
     end
 
@@ -55,6 +64,8 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
                              camera_id: camera.id, lens_id: lens.id } }
 
       expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
+      perform_enqueued_jobs
+
       draft = Image.order(:id).last
       # EXIF（SONY ILCE-7CM2）ではなく手動選択が勝つ。taken_at は EXIF から入る
       expect(draft.camera).to eq(camera)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,32 @@
+# ローカル Traefik（homelab/local/traefik）経由のルーティング層
+# - frontend: http://portfolio.localhost
+# - backend:  http://api.portfolio.localhost
+# 既存の ports 公開（localhost:3002 / :3000）はそのまま残る（e2e 等の互換用）
+services:
+  backend:
+    networks:
+      - default
+      - traefik
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.portfolio-api.rule=Host(`api.portfolio.localhost`)
+      - traefik.http.services.portfolio-api.loadbalancer.server.port=3000
+    environment:
+      FRONTEND_ORIGIN: 'http://portfolio.localhost'
+      # Rails HostAuthorization に Traefik 経由のホスト名を許可させる（development のみ有効な標準 env）
+      RAILS_DEVELOPMENT_HOSTS: 'api.portfolio.localhost'
+  frontend:
+    networks:
+      - default
+      - traefik
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.portfolio.rule=Host(`portfolio.localhost`)
+      - traefik.http.services.portfolio.loadbalancer.server.port=3002
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: 'http://api.portfolio.localhost/api'
+
+networks:
+  traefik:
+    external: true
+    name: traefik

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ services:
     environment:
       RAILS_ENV: production
       DATABASE_URL: postgres://backend:${BACKEND_DATABASE_PASSWORD}@db:5432/backend_production
+      # Solid Queue ワーカーを Puma 内で起動（config/puma.rb の plugin を有効化）
+      SOLID_QUEUE_IN_PUMA: "1"
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       PGHOST: db
       FRONTEND_ORIGIN: "http://localhost:3002"
+      # Solid Queue ワーカーを Puma 内で起動（本番と同じ構成）
+      SOLID_QUEUE_IN_PUMA: "1"
     depends_on:
       - db
   frontend:


### PR DESCRIPTION
## 概要
EXIF 補完・analyze・variant 生成をリクエスト内同期処理から ProcessAttachedFileJob に移し、一括取込を枚数によらず即応答にする。

Closes #271

## レビュー優先度
🔴 全文レビュー — 全生成経路の添付処理を非同期化するアーキテクチャ変更

## 判断・トレードオフ
- **Solid Queue をメイン DB に同居**（installer 既定の separate queue DB は不採用）: 規模が小さく、バックアップ・運用を一本化するため。生成された `db/queue_schema.rb` は通常 migration に変換
- **ワーカーは Puma 内**（`SOLID_QUEUE_IN_PUMA`）: コンテナ追加ゼロで compose/CD 据え置き。vips のメモリ負荷が問題になったら worker service に分離
- **処理状態カラムは追加しない**: analyze 済み・variant 有無から導出（`attached_file_needs_processing?`）。失敗の真実の源は Solid Queue の failed executions で、mission_control-jobs を `/admin/jobs` に mount（認証は Admin::Base 委譲、HTTP Basic 無効）
- **ジョブは analyze → variant → EXIF補完(save) の順**: save 時の after_commit 再エンキュー判定を false にして連鎖を遮断
- **`retry_on ActiveStorage::FileNotFoundError, attempts: 5`**: io attach 経路では after_commit のエンキューが S3 アップロード完了より先に走る race がある（dev 実機で再現）。transient として有限リトライ、使い切ったら fail-loud
- EXIF の `before_validation on: :create` 同期補完は廃止。空欄のみ補完（human input wins）のセマンティクスはジョブ側でも維持

## 確認
- rspec 140 examples 0 failures / rubocop 78 files clean（docker compose exec, RAILS_ENV=test）
- dev 実機 E2E: runner で io attach → ジョブが EXIF（taken_at/camera/lens）・analyze（width/height）・variant×2 を完走、failed jobs 0。race 発生時のリトライ回復も確認
- `/admin/jobs` 未認証アクセスは 302（Devise ログインへ）
- `RAILS_ENV=production bin/rails assets:precompile` 成功（mission_control 同梱アセット含む）
- 未確認: 管理画面の実描画（ダッシュボードのジョブリンク・取込フロー・Mission Control UI の prod CSP 相性）はユーザー手動確認待ち

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)