### PR TITLE
feat(backend): 一括取込の重複検出と孤立 blob の後始末

### DIFF
--- a/backend/app/controllers/admin/image_bulk_imports_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_imports_controller.rb
@@ -18,16 +18,7 @@ class Admin::ImageBulkImportsController < Admin::Base
     end
 
     @results = signed_ids.map { |signed_id| ingest_draft(signed_id, shared_attributes) }
-    failed = @results.count { |result| result[:image].nil? || !result[:image].persisted? }
-
-    if failed.zero?
-      redirect_to admin_images_path(filter: "uncurated"),
-                  notice: "#{@results.size}枚を下書きとして取り込みました。EXIF・サムネイルはバックグラウンドで処理されます。" \
-                          "1枚ずつタイトルを付けて公開してください。"
-    else
-      flash.now[:alert] = "#{failed}枚の取り込みに失敗しました（#{@results.size - failed}枚は成功）。"
-      render :new, status: :unprocessable_content
-    end
+    respond_with_results
   end
 
   private
@@ -39,7 +30,7 @@ class Admin::ImageBulkImportsController < Admin::Base
   end
 
   # 全画像に共通で付ける属性。camera/lens は明示指定があれば EXIF より優先される
-  # （モデルの fill_metadata_from_exif は空欄しか埋めないため、渡すだけで成立する）。
+  # （モデルの EXIF 補完は空欄しか埋めないため、渡すだけで成立する）。
   def shared_attributes
     {
       category_ids: Array(params.dig(:bulk, :category_ids)).compact_blank,
@@ -48,12 +39,49 @@ class Admin::ImageBulkImportsController < Admin::Base
     }.compact
   end
 
+  # 結果は { filename:, status: :created | :duplicate | :failed, image:, errors: }
   def ingest_draft(signed_id, shared_attributes)
     blob = ActiveStorage::Blob.find_signed!(signed_id)
-    image = Image.new(file: signed_id, is_published: false, **shared_attributes)
-    image.save
-    { filename: blob.filename.to_s, image: image, errors: image.errors.full_messages }
+
+    if (existing = Image.duplicate_for_blob(blob))
+      # 重複分の direct-upload blob は不要なので回収する。ただし attach 済み
+      # （同一 signed_id の二重 POST）の blob を消すと既存画像のファイルが消える
+      blob.purge_later if blob.attachments.none?
+      return { filename: blob.filename.to_s, status: :duplicate, image: existing, errors: [] }
+    end
+
+    persist_draft(blob, signed_id, shared_attributes)
   rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
-    { filename: signed_id.to_s.truncate(24), image: nil, errors: ['アップロードが無効です（再アップロードしてください）'] }
+    { filename: signed_id.to_s.truncate(24), status: :failed, image: nil,
+      errors: ['アップロードが無効です（再アップロードしてください）'] }
+  end
+
+  def persist_draft(blob, signed_id, shared_attributes)
+    image = Image.new(file: signed_id, is_published: false, **shared_attributes)
+    if image.save
+      { filename: blob.filename.to_s, status: :created, image: image, errors: [] }
+    else
+      # save 失敗時は未 attach の blob が S3 に残るため即時回収する
+      blob.purge_later
+      { filename: blob.filename.to_s, status: :failed, image: nil, errors: image.errors.full_messages }
+    end
+  end
+
+  def respond_with_results
+    counts = Hash.new(0).merge(@results.group_by { |r| r[:status] }.transform_values(&:size))
+
+    if counts[:failed].zero?
+      redirect_to admin_images_path(filter: "uncurated"), notice: import_notice(counts)
+    else
+      flash.now[:alert] = "#{counts[:failed]}枚の取り込みに失敗しました" \
+                          "（成功 #{counts[:created]}枚・重複スキップ #{counts[:duplicate]}枚）。"
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def import_notice(counts)
+    notice = "#{counts[:created]}枚を下書きとして取り込みました。"
+    notice += "#{counts[:duplicate]}枚は取り込み済みのためスキップしました。" if counts[:duplicate].positive?
+    "#{notice}EXIF・サムネイルはバックグラウンドで処理されます。1枚ずつタイトルを付けて公開してください。"
   end
 end

--- a/backend/app/jobs/process_attached_file_job.rb
+++ b/backend/app/jobs/process_attached_file_job.rb
@@ -8,7 +8,10 @@ class ProcessAttachedFileJob < ApplicationJob
   # io attach（rake/runner/フォーム）では after_commit のエンキューが S3 アップロード
   # 完了より先に走りうる（callback 定義順の race）。transient なので有限リトライし、
   # 使い切ったら fail-loud（failed executions に残る）。
-  retry_on ActiveStorage::FileNotFoundError, wait: :polynomially_longer, attempts: 5
+  # NoSuchKey も対象: S3Service#stream はチャンク GET 途中の NoSuchKey を
+  # FileNotFoundError に包まず生のまま上げる（初回 GET しか wrap されない）。
+  retry_on ActiveStorage::FileNotFoundError, Aws::S3::Errors::NoSuchKey,
+           wait: :polynomially_longer, attempts: 5
 
   def perform(record)
     record.process_attached_file!

--- a/backend/app/jobs/purge_unattached_blobs_job.rb
+++ b/backend/app/jobs/purge_unattached_blobs_job.rb
@@ -1,0 +1,14 @@
+# direct upload 後に attach されなかった blob（フォーム離脱・save 失敗の取りこぼし等）を
+# 定期回収する安全網。即時 purge（取込失敗時）で拾えないケースをここで拾う。
+# config/recurring.yml から日次で起動される。
+class PurgeUnattachedBlobsJob < ApplicationJob
+  queue_as :default
+
+  # direct upload からフォーム送信までの猶予。これより新しい未 attach blob は
+  # 進行中のアップロードの可能性があるため残す。
+  RETENTION = 2.days
+
+  def perform
+    ActiveStorage::Blob.unattached.where(created_at: ..RETENTION.ago).find_each(&:purge_later)
+  end
+end

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -76,6 +76,17 @@ class Image < ApplicationRecord
     images
   end
 
+  # 同一ファイル（checksum + byte_size 一致）を持つ既存レコードを返す。
+  # 一括取込の重複スキップ判定に使う（DB unique index は direct upload の
+  # blob 作成時点で弾いてしまうため、アプリ層で ingest 時に照合する）。
+  # 未 attach の新規 blob は join に現れないため自分自身とは一致しない。
+  # 同一 signed_id の二重 POST では attach 済みの自分に一致し、重複として弾ける。
+  def self.duplicate_for_blob(blob)
+    joins(file_attachment: :blob)
+      .where(active_storage_blobs: { checksum: blob.checksum, byte_size: blob.byte_size })
+      .first
+  end
+
   def self.filter_by_categories(category_ids)
     return all if category_ids.blank?
 

--- a/backend/app/views/admin/image_bulk_imports/new.html.haml
+++ b/backend/app/views/admin/image_bulk_imports/new.html.haml
@@ -7,8 +7,11 @@
 - if @results.present?
   %ul.list-group.mb-3
     - @results.each do |result|
-      - if result[:image]&.persisted?
+      - case result[:status]
+      - when :created
         %li.list-group-item.list-group-item-success ✓ #{result[:filename]} — 下書きとして作成しました
+      - when :duplicate
+        %li.list-group-item.list-group-item-warning ⏭ #{result[:filename]} — 取り込み済みのためスキップしました
       - else
         %li.list-group-item.list-group-item-danger ✗ #{result[:filename]} — #{result[:errors].join('、')}
 

--- a/backend/config/recurring.yml
+++ b/backend/config/recurring.yml
@@ -13,3 +13,7 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  # 未 attach blob の定期回収（即時 purge の安全網）。時刻は UTC
+  purge_unattached_blobs:
+    class: PurgeUnattachedBlobsJob
+    schedule: every day at 5am

--- a/backend/spec/jobs/purge_unattached_blobs_job_spec.rb
+++ b/backend/spec/jobs/purge_unattached_blobs_job_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe PurgeUnattachedBlobsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  def create_blob
+    ActiveStorage::Blob.create_and_upload!(
+      io: Rails.root.join('spec/fixtures/files/test_image.jpg').open,
+      filename: 'test_image.jpg', content_type: 'image/jpeg'
+    )
+  end
+
+  it 'purges unattached blobs older than the retention period' do
+    stale = create_blob
+    stale.update!(created_at: (described_class::RETENTION + 1.hour).ago)
+
+    described_class.perform_now
+    perform_enqueued_jobs
+
+    expect(ActiveStorage::Blob.exists?(stale.id)).to be(false)
+  end
+
+  it 'keeps recent unattached blobs (upload may be in progress)' do
+    fresh = create_blob
+
+    described_class.perform_now
+    perform_enqueued_jobs
+
+    expect(ActiveStorage::Blob.exists?(fresh.id)).to be(true)
+  end
+
+  it 'keeps attached blobs regardless of age' do
+    image = create(:image)
+    image.file.blob.update!(created_at: (described_class::RETENTION + 1.hour).ago)
+
+    described_class.perform_now
+    perform_enqueued_jobs
+
+    expect(ActiveStorage::Blob.exists?(image.file.blob.id)).to be(true)
+  end
+end

--- a/backend/spec/requests/admin/image_bulk_imports_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_imports_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
     )
   end
 
+  # checksum 重複にならない一意な画像（グレー値でバイト列を変える）
+  def upload_unique_blob(shade)
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new((Vips::Image.black(4, 4) + shade).cast(:uchar).write_to_buffer('.png')),
+      filename: "unique_#{shade}.png",
+      content_type: 'image/png'
+    )
+  end
+
   describe 'GET /admin/image_bulk_import/new' do
     it 'renders the bulk import form' do
       get '/admin/image_bulk_import/new'
@@ -28,7 +37,7 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
   describe 'POST /admin/image_bulk_import' do
     it 'creates a draft per file with shared categories; EXIF fills after the job runs' do
       category = create(:category)
-      signed_ids = [upload_fixture_blob.signed_id, upload_fixture_blob.signed_id]
+      signed_ids = [upload_fixture_blob.signed_id, upload_unique_blob(10).signed_id]
 
       expect do
         post '/admin/image_bulk_import',
@@ -48,11 +57,51 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
 
       perform_enqueued_jobs
 
-      drafts.each(&:reload)
-      drafts.each do |draft|
-        expect(draft.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
-        expect(draft.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
-      end
+      # EXIF は fixture 側（1枚目）にのみ入っている
+      exif_draft = drafts.first.reload
+      expect(exif_draft.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
+      expect(exif_draft.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
+    end
+
+    it 'skips duplicates within a batch and purges the redundant blob' do
+      first_blob = upload_fixture_blob
+      duplicate_blob = upload_fixture_blob
+
+      expect do
+        post '/admin/image_bulk_import',
+             params: { bulk: { files: [first_blob.signed_id, duplicate_blob.signed_id] } }
+      end.to change(Image, :count).by(1)
+
+      expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
+      expect(flash[:notice]).to include('1枚は取り込み済みのためスキップ')
+
+      perform_enqueued_jobs
+      expect(ActiveStorage::Blob.exists?(duplicate_blob.id)).to be(false)
+      expect(ActiveStorage::Blob.exists?(first_blob.id)).to be(true)
+    end
+
+    it 'skips a file that was already imported in a previous batch' do
+      post '/admin/image_bulk_import', params: { bulk: { files: [upload_fixture_blob.signed_id] } }
+
+      expect do
+        post '/admin/image_bulk_import', params: { bulk: { files: [upload_fixture_blob.signed_id] } }
+      end.not_to change(Image, :count)
+
+      expect(flash[:notice]).to include('スキップ')
+    end
+
+    it 'purges the blob when the draft fails to save' do
+      blob = upload_fixture_blob
+      allow_any_instance_of(Image).to receive(:save).and_return(false)
+
+      expect do
+        post '/admin/image_bulk_import', params: { bulk: { files: [blob.signed_id] } }
+      end.not_to change(Image, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+
+      perform_enqueued_jobs
+      expect(ActiveStorage::Blob.exists?(blob.id)).to be(false)
     end
 
     it 'applies an explicitly chosen shared camera/lens over EXIF' do


### PR DESCRIPTION
## 概要
同一ファイルの再取込を checksum 照合でスキップし、attach されなかった direct-upload blob を即時 + 定期の両輪で回収する。

Closes #272

**Stacked PR**: base は #274（Solid Queue 導入）。#274 マージ後に base が main に切り替わってからマージすること。

## レビュー優先度
🔴 全文レビュー — 取込フローの分岐追加と blob 削除ロジック（誤削除リスクのある変更）

## 判断・トレードオフ
- **重複検出はアプリ層（`Image.duplicate_for_blob`、checksum + byte_size）**: DB unique index は direct upload の blob 作成時点（ingest 前）で 500 になるため不採用
- **`where.not(id: blob.id)` を意図的に入れていない**: 未 attach の新規 blob はそもそも join に現れない。除外すると同一 signed_id の二重 POST が素通りし、同一 blob を共有する Image が2枚できて片方の destroy が他方のファイルを消す
- **purge は `blob.attachments.none?` ガード付き**: 同上の二重 POST ケースで attach 済み blob を消さないため
- **回収は即時 + 日次 sweep の両輪**: 即時 purge は既知の失敗しか拾えない（フォーム離脱等は残る）。`PurgeUnattachedBlobsJob` が 2 日超の未 attach blob を回収（進行中アップロードの猶予）
- **retry_on に `Aws::S3::Errors::NoSuchKey` 追加**: Active Storage の `S3Service#stream` はチャンク GET 途中の NoSuchKey を初回 GET しか `FileNotFoundError` に wrap せず、生エラーが即 failed になっていた（dev 実機で発生）

## 確認
- rspec 146 examples 0 failures / rubocop 80 files clean
- dev 実機: 同一バイト列 blob で既存 Image を検出・非重複は nil、stale 未 attach blob の回収と fresh の温存、取込 E2E failed jobs 0（NoSuchKey リトライ回復含む）
- 未確認: 取込画面の実描画（⏭ 重複スキップ行の表示）はユーザー手動確認待ち

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)