### PR TITLE
feat(backend): 一括取込にchecksum重複検出と孤立blobの後始末を追加

### DIFF
--- a/backend/app/controllers/admin/image_bulk_imports_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_imports_controller.rb
@@ -18,14 +18,19 @@ class Admin::ImageBulkImportsController < Admin::Base
     end
 
     @results = signed_ids.map { |signed_id| ingest_draft(signed_id, shared_attributes) }
-    failed = @results.count { |result| result[:image].nil? || !result[:image].persisted? }
+    failed = @results.count { |result| result[:status] == :failed }
+    duplicates = @results.count { |result| result[:status] == :duplicate }
+    created = @results.size - failed - duplicates
 
-    if failed.zero?
+    if failed.zero? && duplicates.zero?
       redirect_to admin_images_path(filter: "uncurated"),
-                  notice: "#{@results.size}枚を下書きとして取り込みました。EXIF・サムネイルはバックグラウンドで処理されます。" \
+                  notice: "#{created}枚を下書きとして取り込みました。EXIF・サムネイルはバックグラウンドで処理されます。" \
                           "1枚ずつタイトルを付けて公開してください。"
+    elsif failed.zero?
+      flash.now[:notice] = "#{created}枚を下書きとして取り込みました（#{duplicates}枚は登録済みのため重複としてスキップしました）。"
+      render :new, status: :ok
     else
-      flash.now[:alert] = "#{failed}枚の取り込みに失敗しました（#{@results.size - failed}枚は成功）。"
+      flash.now[:alert] = "#{failed}枚の取り込みに失敗しました（#{created}枚は成功、#{duplicates}枚は重複でスキップ）。"
       render :new, status: :unprocessable_content
     end
   end
@@ -48,12 +53,28 @@ class Admin::ImageBulkImportsController < Admin::Base
     }.compact
   end
 
+  # checksum + byte_size が既存の Image#file と一致すれば重複としてスキップする。
+  # direct upload は request 到達前に S3 アップロード済みなので、スキップ時・save 失敗時
+  # は新規 blob を purge_later して孤立させない（同一バッチ内の重複も、前の反復の
+  # image.save がここに来る前にコミット済みのため、この DB 照合だけで検出できる）。
   def ingest_draft(signed_id, shared_attributes)
     blob = ActiveStorage::Blob.find_signed!(signed_id)
+    filename = blob.filename.to_s
+
+    if (duplicate = Image.attached_duplicate_for(blob))
+      blob.purge_later
+      return { filename: filename, status: :duplicate, image: nil, duplicate_image_id: duplicate.id, errors: [] }
+    end
+
     image = Image.new(file: signed_id, is_published: false, **shared_attributes)
-    image.save
-    { filename: blob.filename.to_s, image: image, errors: image.errors.full_messages }
+    if image.save
+      { filename: filename, status: :created, image: image, duplicate_image_id: nil, errors: [] }
+    else
+      blob.purge_later
+      { filename: filename, status: :failed, image: nil, duplicate_image_id: nil, errors: image.errors.full_messages }
+    end
   rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
-    { filename: signed_id.to_s.truncate(24), image: nil, errors: ['アップロードが無効です（再アップロードしてください）'] }
+    { filename: signed_id.to_s.truncate(24), status: :failed, image: nil, duplicate_image_id: nil,
+      errors: ['アップロードが無効です（再アップロードしてください）'] }
   end
 end

--- a/backend/app/jobs/unattached_blobs_cleanup_job.rb
+++ b/backend/app/jobs/unattached_blobs_cleanup_job.rb
@@ -1,0 +1,14 @@
+# 一括取込での重複検出・保存失敗時は purge_later で都度後始末するが、プロセス異常終了
+# 等で漏れた孤立 blob（direct upload は S3 アップロード前に blob 行ができるため発生しうる）
+# の保険。24時間より古い未 attach blob だけを対象にし、アップロード中の新しい blob は
+# 消さない。config/recurring.yml から日次で起動。
+# purge は例外を rescue しない（fail-loud）：失敗は Solid Queue の failed executions に残る。
+class UnattachedBlobsCleanupJob < ApplicationJob
+  queue_as :default
+
+  STALE_AFTER = 24.hours
+
+  def perform
+    ActiveStorage::Blob.unattached.where(created_at: ...STALE_AFTER.ago).find_each(&:purge)
+  end
+end

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -81,6 +81,14 @@ class Image < ApplicationRecord
     images
   end
 
+  # checksum + byte_size で「file として添付済みの Image」を探す（一括取込の重複検出用）。
+  # direct upload は blob 行が S3 アップロード前に作られるため DB の unique index では
+  # 防げず、アプリ側でここに一本化して照合する。file_blob 経由なので variant 等の blob
+  # とは誤照合しない（has_one_attached が record_type/name を自動でスコープする）。
+  def self.attached_duplicate_for(blob)
+    joins(:file_blob).find_by(active_storage_blobs: { checksum: blob.checksum, byte_size: blob.byte_size })
+  end
+
   def self.filter_by_categories(category_ids)
     return all if category_ids.blank?
 

--- a/backend/app/views/admin/image_bulk_imports/new.html.haml
+++ b/backend/app/views/admin/image_bulk_imports/new.html.haml
@@ -7,8 +7,11 @@
 - if @results.present?
   %ul.list-group.mb-3
     - @results.each do |result|
-      - if result[:image]&.persisted?
+      - case result[:status]
+      - when :created
         %li.list-group-item.list-group-item-success ✓ #{result[:filename]} — 下書きとして作成しました
+      - when :duplicate
+        %li.list-group-item.list-group-item-warning ⚠ #{result[:filename]} — 既存の画像（ID: #{result[:duplicate_image_id]}）と重複のためスキップしました
       - else
         %li.list-group-item.list-group-item-danger ✗ #{result[:filename]} — #{result[:errors].join('、')}
 

--- a/backend/config/recurring.yml
+++ b/backend/config/recurring.yml
@@ -13,3 +13,7 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  unattached_blobs_cleanup:
+    class: UnattachedBlobsCleanupJob
+    queue: default
+    schedule: at 3am every day

--- a/backend/spec/jobs/unattached_blobs_cleanup_job_spec.rb
+++ b/backend/spec/jobs/unattached_blobs_cleanup_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe UnattachedBlobsCleanupJob, type: :job do
+  def create_blob(created_at:)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: Rails.root.join('spec/fixtures/files/test_image.jpg').open,
+      filename: 'test_image.jpg',
+      content_type: 'image/jpeg'
+    )
+    blob.update!(created_at: created_at)
+    blob
+  end
+
+  it 'purges unattached blobs older than 24 hours' do
+    stale_blob = create_blob(created_at: 25.hours.ago)
+
+    described_class.perform_now
+
+    expect(ActiveStorage::Blob.exists?(stale_blob.id)).to be(false)
+  end
+
+  it 'keeps unattached blobs newer than 24 hours' do
+    fresh_blob = create_blob(created_at: 1.hour.ago)
+
+    described_class.perform_now
+
+    expect(ActiveStorage::Blob.exists?(fresh_blob.id)).to be(true)
+  end
+
+  it 'keeps attached blobs regardless of age' do
+    image = create(:image, :draft)
+    image.file.blob.update!(created_at: 25.hours.ago)
+
+    described_class.perform_now
+
+    expect(ActiveStorage::Blob.exists?(image.file.blob.id)).to be(true)
+  end
+end

--- a/backend/spec/requests/admin/image_bulk_imports_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_imports_spec.rb
@@ -26,33 +26,28 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
   end
 
   describe 'POST /admin/image_bulk_import' do
-    it 'creates a draft per file with shared categories; EXIF fills after the job runs' do
+    it 'creates a draft with shared categories; EXIF fills after the job runs' do
       category = create(:category)
-      signed_ids = [upload_fixture_blob.signed_id, upload_fixture_blob.signed_id]
 
       expect do
         post '/admin/image_bulk_import',
-             params: { bulk: { files: signed_ids, category_ids: [category.id] } }
-      end.to change(Image, :count).by(2)
+             params: { bulk: { files: [upload_fixture_blob.signed_id], category_ids: [category.id] } }
+      end.to change(Image, :count).by(1)
 
       expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
 
       # リクエスト内では S3 ダウンロードを伴う処理をしない（EXIF はジョブで補完）
-      drafts = Image.order(:id).last(2)
-      drafts.each do |draft|
-        expect(draft.is_published).to be(false)
-        expect(draft.title).to be_nil
-        expect(draft.taken_at).to be_nil
-        expect(draft.categories).to eq([category])
-      end
+      draft = Image.order(:id).last
+      expect(draft.is_published).to be(false)
+      expect(draft.title).to be_nil
+      expect(draft.taken_at).to be_nil
+      expect(draft.categories).to eq([category])
 
       perform_enqueued_jobs
 
-      drafts.each(&:reload)
-      drafts.each do |draft|
-        expect(draft.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
-        expect(draft.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
-      end
+      draft.reload
+      expect(draft.taken_at).to eq(Time.utc(2024, 1, 1, 3, 56, 27))
+      expect(draft.camera).to have_attributes(make: 'SONY', model: 'ILCE-7CM2')
     end
 
     it 'applies an explicitly chosen shared camera/lens over EXIF' do
@@ -90,6 +85,60 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
       end.not_to change(Image, :count)
 
       expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    describe 'checksum ベースの重複検出' do
+      it 'collapses a duplicate file within the same batch and purges the extra blob' do
+        blob1 = upload_fixture_blob
+        blob2 = upload_fixture_blob
+
+        expect do
+          post '/admin/image_bulk_import', params: { bulk: { files: [blob1.signed_id, blob2.signed_id] } }
+        end.to change(Image, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        created_image = Image.order(:id).last
+        expect(response.body).to include("既存の画像（ID: #{created_image.id}）と重複")
+
+        perform_enqueued_jobs
+
+        # blob1 は Image に添付されて残り、blob2（重複と判定された方）だけ purge される
+        expect(ActiveStorage::Blob.exists?(blob1.id)).to be(true)
+        expect(ActiveStorage::Blob.exists?(blob2.id)).to be(false)
+      end
+
+      it 'detects a duplicate against a blob already attached from an earlier import and purges the new blob' do
+        post '/admin/image_bulk_import', params: { bulk: { files: [upload_fixture_blob.signed_id] } }
+        existing_image = Image.order(:id).last
+
+        second_blob = upload_fixture_blob
+
+        expect do
+          post '/admin/image_bulk_import', params: { bulk: { files: [second_blob.signed_id] } }
+        end.not_to change(Image, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("既存の画像（ID: #{existing_image.id}）と重複")
+
+        perform_enqueued_jobs
+        expect(ActiveStorage::Blob.exists?(second_blob.id)).to be(false)
+      end
+    end
+
+    describe 'save 失敗時の孤立 blob 後始末' do
+      it 'purges the newly uploaded blob when image.save fails' do
+        allow_any_instance_of(Image).to receive(:save).and_return(false)
+        blob = upload_fixture_blob
+
+        expect do
+          post '/admin/image_bulk_import', params: { bulk: { files: [blob.signed_id] } }
+        end.not_to change(Image, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+
+        perform_enqueued_jobs
+        expect(ActiveStorage::Blob.exists?(blob.id)).to be(false)
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
一括取込で同一ファイルの二重登録を checksum + byte_size 照合で検出してスキップし、取込失敗・重複時と定期ジョブの二段構えで未 attach blob が S3 に残留しないようにする。

Closes #272

## レビュー優先度
🔴 全文レビュー — 取込フローのロジック変更 + 新規定期ジョブ

## 判断・トレードオフ
- **DB unique index ではなくアプリ側照合**: direct upload は blob 行が S3 アップロード前に作られるため、checksum への unique index では防げない。照合は `Image.attached_duplicate_for` に一本化（`file_blob` join なので variant blob と誤照合しない）
- **重複ありの場合は redirect せず結果画面を表示**: 従来の成功/失敗2分岐のままだと duplicate ステータスがユーザーに一切見えないため、「全成功→redirect / 失敗0・重複あり→200で結果表示 / 失敗あり→422」の3分岐にした
- **定期後始末は24時間猶予**: アップロード進行中の新しい未 attach blob を誤 purge しないためのマージン。purge は rescue しない fail-loud（失敗は Solid Queue の failed executions に残る）

## 確認
- `bundle exec rspec` 146 examples / 0 failures、`bundle exec rubocop` offenses なし（いずれも exit code で確認）
- 重複検出・バッチ内重複・save 失敗時 purge・cleanup job の対象選別は request/job spec で実経路を踏ませて確認
- admin 取込画面の実描画は未確認（作者レビュー時に手動確認予定）。save 失敗経路の spec は現実的な失敗トリガーが見当たらずスタブで強制

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)