### PR TITLE
feat(backend): 画像並び順を featured_rank + taken_at ベースに再設計

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -25,8 +25,6 @@ gem "stimulus-rails"
 
 gem "rack-cors"
 
-gem "ranked-model"
-
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -287,8 +287,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    ranked-model (0.4.11)
-      activerecord (>= 5.2)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -421,7 +419,6 @@ DEPENDENCIES
   puma (>= 6.4)
   rack-cors
   rails (~> 8.1)
-  ranked-model
   rspec-rails
   rubocop
   rubocop-performance

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -6,14 +6,14 @@ class Admin::ImagesController < Admin::Base
   before_action :set_adjacent_images, only: %i[edit update]
 
   def index
-    @images = Image.rank(:row_order).with_attached_file
+    @images = Image.order(:id).with_attached_file
     @uncurated_count = Image.uncurated.count
     @images = @images.uncurated if params[:filter] == "uncurated"
   end
 
-  # 並び替え専用画面。公開ギャラリーの鏡として公開画像のみを表示する。
+  # 並び替え専用画面。featured のみを表示する（ギャラリー先頭に pin される集合）。
   def arrange
-    @images = Image.published.rank(:row_order).with_attached_file
+    @images = Image.featured.with_attached_file
   end
 
   def show; end
@@ -25,11 +25,11 @@ class Admin::ImagesController < Admin::Base
   def edit; end
 
   def create
-    @image = Image.new(image_params.except(:row_order_position))
+    @image = Image.new(image_params.except(:is_featured))
     @image.is_published = publish_intent || false
-    apply_row_order_position(@image)
 
     if @image.save
+      apply_featured_toggle
       redirect_to admin_images_path, notice: update_notice
     else
       flash.now[:alert] = 'Image failed to create.'
@@ -38,12 +38,12 @@ class Admin::ImagesController < Admin::Base
   end
 
   def update
-    @image.assign_attributes(image_params.except(:row_order_position))
+    @image.assign_attributes(image_params.except(:is_featured))
     intent = publish_intent
     @image.is_published = intent unless intent.nil?
-    apply_row_order_position(@image)
 
     if @image.save
+      apply_featured_toggle
       redirect_to after_save_edit_path, notice: update_notice
     else
       # 公開しようとして弾かれた場合もフォームは元の公開状態のまま再描画する
@@ -61,15 +61,16 @@ class Admin::ImagesController < Admin::Base
     end
   end
 
-  # 並び替え画面は公開画像のみを表示するため、ドロップ位置は「公開リスト内の
-  # index」で届く。全画像共有の row_order 空間での position への変換は Image が担う。
+  # 並び替え画面は featured のみを表示するため、ドロップ位置＝featured リスト内 index
+  # ＝そのまま featured_rank。現在の featured 順から対象画像を抜いて挿入位置へ差し込み、
+  # 全体を 0..N-1 へ正規化する。
   def insert_at
-    @image.row_order_position = Image.published_index_to_row_order_position(@image, insert_params.to_i)
-    if @image.save
-      head :ok
-    else
-      render json: { error: @image.errors.full_messages }, status: :unprocessable_content
-    end
+    ids = Image.featured.where.not(id: @image.id).pluck(:id)
+    ids.insert(insert_params.to_i, @image.id)
+    Image.reorder_featured!(ids)
+    head :ok
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+    render json: { error: e.message }, status: :unprocessable_content
   end
 
   # Server-side EXIF resolution for the new/edit form. Takes the signed blob id of
@@ -103,14 +104,24 @@ class Admin::ImagesController < Admin::Base
     @image = Image.find(params[:id])
   end
 
-  def apply_row_order_position(image)
-    image.row_order_position = image_params[:row_order_position].to_i if image_params[:row_order_position].present?
+  # image_params[:is_featured] はチェックボックス経由の仮想属性（featured_rank は
+  # 保存後に Image#feature!/#unfeature! 経由で正規化する）。未送信（新規作成フォーム
+  # 以外での省略等）は変更なしとして扱う。
+  def apply_featured_toggle
+    return if image_params[:is_featured].nil?
+
+    wants_featured = ActiveModel::Type::Boolean.new.cast(image_params[:is_featured])
+    if wants_featured
+      @image.feature!
+    else
+      @image.unfeature!
+    end
   end
 
   def image_params
     params.expect(
       image: [:title, :caption, :taken_at, :camera_id, :lens_id,
-              :row_order_position, :file,
+              :is_featured, :file,
               { category_ids: [] }]
     )
   end

--- a/backend/app/controllers/api/images_controller.rb
+++ b/backend/app/controllers/api/images_controller.rb
@@ -11,12 +11,25 @@ class Api::ImagesController < ApplicationController
 
     render json: {
       images: images.map { |image| image_json(image) },
-      next_cursor: has_more ? "#{images.last.row_order},#{images.last.id}" : nil,
+      next_cursor: has_more ? next_cursor(images.last) : nil,
       has_more: has_more
     }
   end
 
   private
+
+  # 最後の要素の種別に応じて次ページの cursor を組み立てる。
+  # featured なら featured セグメントの続き、時系列なら時系列セグメントの続き。
+  # taken_at はエポックミリ秒に丸める（DB は microsecond 精度）。round だと切り上げで
+  # 元の行の実精度より未来の境界になり得て、次ページの厳密不等号から自分自身が漏れて
+  # 再出現する。floor で必ず自分自身の実精度以下に丸め、境界の取りこぼしを防ぐ。
+  def next_cursor(image)
+    if image.featured_rank.present?
+      "f,#{image.featured_rank},#{image.id}"
+    else
+      "t,#{(image.taken_at.to_f * 1000).floor},#{image.id}"
+    end
+  end
 
   def category_ids_param
     case params[:categories]

--- a/backend/app/controllers/concerns/admin/image_curation_flow.rb
+++ b/backend/app/controllers/concerns/admin/image_curation_flow.rb
@@ -14,11 +14,13 @@ module Admin::ImageCurationFlow
     nil
   end
 
-  # 表示順で隣り合う画像（編集カードの ←/→ の行き先と disabled 判定）
+  # id 順で隣り合う画像（編集カードの ←/→ の行き先と disabled 判定）。
+  # taken_at は下書きで欠けることがあるため id 順を採用する。
   def set_adjacent_images
     @images_total = Image.count
-    @prev_image = Image.rank(:row_order).where(row_order: ...@image.row_order).last
-    @next_image = Image.rank(:row_order).where(row_order: (@image.row_order + 1)..).first
+    @image_position = Image.where(id: ...@image.id).count + 1
+    @prev_image = Image.where(id: ...@image.id).order(id: :desc).first
+    @next_image = Image.where(id: (@image.id + 1)..).order(:id).first
   end
 
   def after_save_edit_path

--- a/backend/app/models/concerns/image_gallery_ordering.rb
+++ b/backend/app/models/concerns/image_gallery_ordering.rb
@@ -1,0 +1,97 @@
+# 画像ギャラリーの並び順（featured pin + taken_at 時系列）とキュレーション操作を集約する。
+# 設計は #273: 手動キュレーションは featured_rank 1本、基本順は taken_at 由来。
+module ImageGalleryOrdering
+  extend ActiveSupport::Concern
+
+  included do
+    # 手動キュレーション（featured）。featured_rank ASC が表示順。
+    scope :featured, -> { where.not(featured_rank: nil).order(:featured_rank) }
+  end
+
+  # ActiveSupport::Concern はネストした ClassMethods モジュールを自動で extend する。
+  # class_methods ブロックにすると Metrics/BlockLength に抵触するため module 定義にする。
+  module ClassMethods
+    # ギャラリーの並びは2段構成：featured を featured_rank ASC で先頭に pin し、
+    # 続けて非 featured を taken_at DESC（時系列）で並べる。featured は時系列側に
+    # 重複して出さない（時系列セグメントは featured_rank IS NULL のみ）。
+    #
+    # cursor は2セグメント keyset の自己記述形式:
+    #   featured セグメント内: "f,<featured_rank>,<id>"
+    #   時系列セグメント内:   "t,<taken_at のエポックミリ秒>,<id>"
+    # featured セグメントを取り切ったら時系列セグメントへ続きから遷移する。
+    def for_gallery(category_ids: nil, cursor: nil, limit: 20)
+      base = published.filter_by_categories(category_ids).with_attached_file.includes(:camera, :lens)
+      parsed_cursor = parse_gallery_cursor(cursor)
+      remaining = limit + 1
+
+      results = gallery_featured_segment(base, parsed_cursor, remaining)
+      remaining -= results.size
+      results.concat(gallery_timeline_segment(base, parsed_cursor, remaining)) if remaining.positive?
+      results
+    end
+
+    # cursor 文字列を { segment:, value:, id: } にパースする。不正な形式は nil（先頭から）。
+    def parse_gallery_cursor(cursor)
+      return nil if cursor.blank?
+
+      segment, value, id = cursor.split(",")
+      return nil unless %w[f t].include?(segment) && value.present? && id.present?
+      return nil unless value.match?(/\A-?\d+\z/) && id.match?(/\A-?\d+\z/)
+
+      { segment: segment == "f" ? :featured : :timeline, value: value.to_i, id: id.to_i }
+    end
+
+    # featured リストの並び替え。渡した順に 0..N-1 へ正規化する。
+    # 含まれない画像（対象外）はそのまま：featured 解除もランクの変更もしない。
+    def reorder_featured!(ids)
+      images = where(id: ids).index_by(&:id)
+      raise ActiveRecord::RecordNotFound, 'Some images not found' if images.size != ids.uniq.size
+
+      transaction do
+        ids.each_with_index { |id, index| images.fetch(id).update!(featured_rank: index) }
+      end
+    end
+
+    private
+
+    def gallery_featured_segment(base, parsed_cursor, remaining)
+      return [] unless parsed_cursor.nil? || parsed_cursor[:segment] == :featured
+
+      scope = base.featured
+      scope = scope.where("(featured_rank, id) > (?, ?)", parsed_cursor[:value], parsed_cursor[:id]) if parsed_cursor
+      scope.limit(remaining).to_a
+    end
+
+    def gallery_timeline_segment(base, parsed_cursor, remaining)
+      scope = base.where(featured_rank: nil).order(taken_at: :desc, id: :desc)
+      if parsed_cursor && parsed_cursor[:segment] == :timeline
+        taken_at_value = Time.zone.at(parsed_cursor[:value] / 1000.0)
+        scope = scope.where("(taken_at, id) < (?, ?)", taken_at_value, parsed_cursor[:id])
+      end
+      scope.limit(remaining).to_a
+    end
+  end
+
+  # featured の末尾に追加する。既に featured なら何もしない。
+  def feature!
+    return if featured_rank.present?
+
+    update!(featured_rank: self.class.featured.count)
+  end
+
+  # featured を解除し、残りの featured_rank を 0..N-1 へ詰め直す。
+  def unfeature!
+    return if featured_rank.blank?
+
+    self.class.transaction do
+      update!(featured_rank: nil)
+      self.class.featured.each_with_index { |image, index| image.update!(featured_rank: index) }
+    end
+  end
+
+  # 編集フォームの featured トグル用の仮想属性（featured_rank の有無から導出）。
+  def featured?
+    featured_rank.present?
+  end
+  alias is_featured featured?
+end

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -1,8 +1,7 @@
 class Image < ApplicationRecord
-  include RankedModel
   include CdnAttachedFile
+  include ImageGalleryOrdering
 
-  ranks :row_order
   THUMBNAIL_LIMIT = [960, 960].freeze
   DISPLAY_LIMIT = [1920, 1920].freeze
 
@@ -26,7 +25,6 @@ class Image < ApplicationRecord
   scope :published, -> { where(is_published: true) }
   scope :draft, -> { where(is_published: false) }
   scope :uncurated, -> { draft.where(title: [nil, ""]) }
-  scope :ordered_for_gallery, -> { order(row_order: :asc, id: :asc) }
 
   validate :taken_at_is_in_the_past
 
@@ -50,22 +48,6 @@ class Image < ApplicationRecord
     save! if changed?
   end
 
-  # 並び替え画面は公開画像のみを表示するため、ドロップ位置は「公開リスト内の index」で
-  # 届く。これを全画像共有の row_order 空間での position に変換する。ドロップ位置の次に
-  # 来る公開画像の直前へ、末尾なら最後の公開画像の直後へ挿入する（末尾より後ろの下書きは
-  # 追い越さない）。全画像が公開のときは index と一致する。
-  def self.published_index_to_row_order_position(image, published_index)
-    others = where.not(id: image.id)
-    published = others.published.rank(:row_order).to_a
-    if (successor = published[published_index])
-      others.where(row_order: ...successor.row_order).count
-    elsif (last = published.last)
-      others.where(row_order: ..last.row_order).count
-    else
-      0
-    end
-  end
-
   # 一括メタデータ付与。nil の属性は変更せず、カテゴリは既存への追加（union）。
   # 部分成功を作らない：ID の欠落や 1 件の失敗で全体をロールバックする（fail-loud）。
   def self.bulk_assign!(ids, camera: nil, lens: nil, categories: [])
@@ -85,23 +67,6 @@ class Image < ApplicationRecord
     return all if category_ids.blank?
 
     where(id: ImageCategory.where(category_id: category_ids).select(:image_id))
-  end
-
-  def self.for_gallery(category_ids: nil, cursor: nil, limit: 20)
-    scope = published
-            .filter_by_categories(category_ids)
-            .with_attached_file
-            .includes(:camera, :lens)
-
-    if cursor.present?
-      parts = cursor.split(",")
-      if parts.size == 2 && parts.all? { |p| p.match?(/\A-?\d+\z/) }
-        row_order_val, id_val = parts.map(&:to_i)
-        scope = scope.where("(row_order, id) > (?, ?)", row_order_val, id_val)
-      end
-    end
-
-    scope.ordered_for_gallery.limit(limit + 1)
   end
 
   private

--- a/backend/app/views/admin/images/_form.html.haml
+++ b/backend/app/views/admin/images/_form.html.haml
@@ -25,7 +25,7 @@
             .d-flex.justify-content-between.align-items-center.mb-3
               = render 'admin/images/status_badge', image: image
               - if local_assigns[:images_total]
-                %small.text-muted= "#{(image.row_order_rank || 0) + 1} / #{local_assigns[:images_total]} 枚目"
+                %small.text-muted= "#{local_assigns[:image_position]} / #{local_assigns[:images_total]} 枚目"
           .mb-3
             = form.label :title, 'タイトル', class: 'form-label fw-bold'
             = form.text_field :title, class: 'form-control', data: { exif_fill_target: "titleInput" }
@@ -36,9 +36,10 @@
             .col-md-6.mb-3
               = form.label :taken_at, '撮影日時', class: 'form-label fw-bold'
               = form.datetime_field :taken_at, class: 'form-control', data: { exif_fill_target: "takenAtInput" }
-            .col-md-6.mb-3
-              = form.label :row_order_position, '表示順（0始まり）', class: 'form-label fw-bold'
-              = form.number_field :row_order_position, class: 'form-control', value: (image.persisted? ? (image.row_order_rank || 0) : nil)
+            .col-md-6.mb-3.d-flex.align-items-end
+              .form-check
+                = form.check_box :is_featured, class: 'form-check-input'
+                = form.label :is_featured, 'おすすめ表示に含める（featured）', class: 'form-check-label'
           .row
             .col-md-6.mb-3
               = form.label :camera_id, 'カメラ', class: 'form-label fw-bold'

--- a/backend/app/views/admin/images/_image.json.jbuilder
+++ b/backend/app/views/admin/images/_image.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! image, :id, :title, :caption, :taken_at, :camera_id, :lens_id, :row_order, :is_published, :created_at,
-              :updated_at
+json.extract! image, :id, :title, :caption, :taken_at, :camera_id, :lens_id, :featured_rank, :is_published,
+              :created_at, :updated_at
 json.url image_url(image, format: :json)

--- a/backend/app/views/admin/images/arrange.html.haml
+++ b/backend/app/views/admin/images/arrange.html.haml
@@ -2,7 +2,7 @@
   %h1.mb-0 並び替え
   = link_to '← 一覧へ戻る', admin_images_path, class: 'btn btn-outline-secondary'
 
-%p.text-muted.small 公開ギャラリーの表示順。ドラッグで即保存されます。
+%p.text-muted.small ギャラリー先頭に固定表示される featured 画像の表示順。ドラッグで即保存されます。
 
 - if @images.any?
   .table-responsive
@@ -21,4 +21,4 @@
             %td= render 'admin/images/image_preview', image: image
             %td= render 'admin/images/image_title', image: image
 - else
-  %p.text-muted 公開中の画像がまだありません。編纂して公開すると、ここに並びます。
+  %p.text-muted featured な画像がまだありません。編集画面で「おすすめ表示に含める」を有効にすると、ここに並びます。

--- a/backend/app/views/admin/images/edit.html.haml
+++ b/backend/app/views/admin/images/edit.html.haml
@@ -1,7 +1,8 @@
 %h1 画像の情報を編集
 
 = render 'form', image: @image, cameras: @cameras, lenses: @lenses, categories: @categories,
-                 prev_image: @prev_image, next_image: @next_image, images_total: @images_total
+                 prev_image: @prev_image, next_image: @next_image, images_total: @images_total,
+                 image_position: @image_position
 
 = link_to '閲覧', admin_image_path(@image)
 \|

--- a/backend/db/migrate/20260709020000_add_featured_rank_replace_row_order_in_images.rb
+++ b/backend/db/migrate/20260709020000_add_featured_rank_replace_row_order_in_images.rb
@@ -1,0 +1,13 @@
+class AddFeaturedRankReplaceRowOrderInImages < ActiveRecord::Migration[8.1]
+  # 画像並び順の設計見直し（#273）。公開ギャラリーの基本順は taken_at 由来に、
+  # 手動キュレーションは featured_rank 1本に一本化する。row_order / ranked-model は廃止。
+  def change
+    add_column :images, :featured_rank, :integer
+    add_index :images, :featured_rank, where: "featured_rank IS NOT NULL"
+    add_index :images, %i[taken_at id]
+
+    remove_index :images, :row_order
+    remove_index :images, :taken_at
+    remove_column :images, :row_order, :integer
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_08_030000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_020000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -80,17 +80,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_030000) do
     t.bigint "camera_id"
     t.string "caption"
     t.datetime "created_at", null: false
+    t.integer "featured_rank"
     t.boolean "is_published", default: false, null: false
     t.bigint "lens_id"
-    t.integer "row_order"
     t.datetime "taken_at"
     t.string "title"
     t.datetime "updated_at", null: false
     t.index ["camera_id"], name: "index_images_on_camera_id"
+    t.index ["featured_rank"], name: "index_images_on_featured_rank", where: "(featured_rank IS NOT NULL)"
     t.index ["is_published"], name: "index_images_on_is_published"
     t.index ["lens_id"], name: "index_images_on_lens_id"
-    t.index ["row_order"], name: "index_images_on_row_order"
-    t.index ["taken_at"], name: "index_images_on_taken_at"
+    t.index ["taken_at", "id"], name: "index_images_on_taken_at_and_id"
   end
 
   create_table "lenses", force: :cascade do |t|

--- a/backend/lib/tasks/e2e.rake
+++ b/backend/lib/tasks/e2e.rake
@@ -35,7 +35,6 @@ def seed_images(camera, lens, category)
       title: "Seed Image #{i + 1}",
       caption: "E2E test image #{i + 1}",
       taken_at: Time.zone.today - i.days,
-      row_order: i,
       is_published: true,
       camera: camera,
       lens: lens

--- a/backend/spec/factories/image.rb
+++ b/backend/spec/factories/image.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     title { Faker::Lorem.word }
     caption { Faker::Lorem.sentence }
     taken_at { Faker::Date.between(from: 1.year.ago, to: Time.zone.today) }
-    row_order { 1 }
     is_published { true }
     camera { build(:camera) }
     lens { build(:lens) }
@@ -17,6 +16,11 @@ FactoryBot.define do
       is_published { false }
       camera { nil }
       lens { nil }
+    end
+
+    # 手動キュレーション対象。featured_rank は呼び出し側で明示指定して重複を避ける想定。
+    trait :featured do
+      featured_rank { 0 }
     end
   end
 end

--- a/backend/spec/models/image_spec.rb
+++ b/backend/spec/models/image_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe Image, type: :model do
       end
     end
 
-    context 'row_order' do
-      it 'should be valid with row_order' do
-        image.row_order = 1
+    context 'featured_rank' do
+      it 'should be valid with featured_rank' do
+        image.featured_rank = 1
         expect(image).to be_valid
       end
     end
@@ -203,15 +203,15 @@ RSpec.describe Image, type: :model do
   end
 
   describe '.for_gallery' do
-    let!(:img1) { create(:image, title: 'A', row_order: 0, is_published: true) }
-    let!(:img2) { create(:image, title: 'B', row_order: 1, is_published: true) }
-    let!(:img3) { create(:image, title: 'C', row_order: 2, is_published: true) }
-    let!(:img4) { create(:image, title: 'D', row_order: 3, is_published: true) }
-    let!(:unpublished) { create(:image, title: 'Hidden', row_order: 4, is_published: false) }
+    let!(:img1) { create(:image, title: 'A', taken_at: 4.days.ago, is_published: true) }
+    let!(:img2) { create(:image, title: 'B', taken_at: 3.days.ago, is_published: true) }
+    let!(:img3) { create(:image, title: 'C', taken_at: 2.days.ago, is_published: true) }
+    let!(:img4) { create(:image, title: 'D', taken_at: 1.day.ago, is_published: true) }
+    let!(:unpublished) { create(:image, title: 'Hidden', taken_at: 5.days.ago, is_published: false) }
 
-    it 'returns only published images ordered by row_order, id' do
+    it 'returns only published images ordered by taken_at desc, id desc when none are featured' do
       result = Image.for_gallery(limit: 10)
-      expect(result.map(&:title)).to eq(%w[A B C D])
+      expect(result.map(&:title)).to eq(%w[D C B A])
     end
 
     it 'excludes unpublished images' do
@@ -224,10 +224,10 @@ RSpec.describe Image, type: :model do
       expect(result.size).to eq(3)
     end
 
-    it 'returns records after cursor position' do
-      cursor = "#{img2.row_order},#{img2.id}"
+    it 'returns timeline records after cursor position' do
+      cursor = "t,#{(img3.taken_at.to_f * 1000).floor},#{img3.id}"
       result = Image.for_gallery(cursor: cursor, limit: 10)
-      expect(result.map(&:title)).to eq(%w[C D])
+      expect(result.map(&:title)).to eq(%w[B A])
     end
 
     it 'filters by category_ids' do
@@ -236,7 +236,7 @@ RSpec.describe Image, type: :model do
       img3.categories << cat
 
       result = Image.for_gallery(category_ids: [cat.id], limit: 10)
-      expect(result.map(&:title)).to eq(%w[A C])
+      expect(result.map(&:title)).to eq(%w[C A])
     end
 
     it 'combines cursor and category filter' do
@@ -244,9 +244,138 @@ RSpec.describe Image, type: :model do
       img1.categories << cat
       img3.categories << cat
 
-      cursor = "#{img1.row_order},#{img1.id}"
+      cursor = "t,#{(img3.taken_at.to_f * 1000).floor},#{img3.id}"
       result = Image.for_gallery(category_ids: [cat.id], cursor: cursor, limit: 10)
-      expect(result.map(&:title)).to eq(%w[C])
+      expect(result.map(&:title)).to eq(%w[A])
+    end
+
+    context 'with featured images' do
+      let!(:feat1) do
+        create(:image, :featured, title: 'F1', featured_rank: 0, taken_at: 10.days.ago, is_published: true)
+      end
+      let!(:feat2) do
+        create(:image, :featured, title: 'F2', featured_rank: 1, taken_at: 9.days.ago, is_published: true)
+      end
+
+      it 'pins featured images ahead of the timeline, ordered by featured_rank' do
+        result = Image.for_gallery(limit: 10)
+        expect(result.map(&:title)).to eq(%w[F1 F2 D C B A])
+      end
+
+      it 'does not duplicate featured images in the timeline segment' do
+        result = Image.for_gallery(limit: 10)
+        expect(result.map(&:title).count('F1')).to eq(1)
+        expect(result.map(&:title).count('F2')).to eq(1)
+      end
+
+      it 'paginates across the featured -> timeline boundary and round-trips the cursor' do
+        first = Image.for_gallery(limit: 2)
+        expect(first.size).to eq(3) # limit + 1 fetched for has_more detection
+        first_page = first.take(2)
+        expect(first_page.map(&:title)).to eq(%w[F1 F2])
+
+        last = first_page.last
+        cursor = "f,#{last.featured_rank},#{last.id}"
+
+        second = Image.for_gallery(cursor: cursor, limit: 2)
+        expect(second.size).to eq(3) # B, A still remain after this page
+        expect(second.take(2).map(&:title)).to eq(%w[D C])
+      end
+
+      it 'round-trips a cursor that lands mid-featured-segment' do
+        cursor = "f,#{feat1.featured_rank},#{feat1.id}"
+        result = Image.for_gallery(cursor: cursor, limit: 10)
+        expect(result.map(&:title)).to eq(%w[F2 D C B A])
+      end
+
+      it 'transitions from an exhausted featured cursor straight into the timeline' do
+        cursor = "f,#{feat2.featured_rank},#{feat2.id}"
+        result = Image.for_gallery(cursor: cursor, limit: 10)
+        expect(result.map(&:title)).to eq(%w[D C B A])
+      end
+
+      it 'combines featured pinning with category filtering' do
+        cat = create(:category, name: 'Landscape')
+        feat2.categories << cat
+        img3.categories << cat
+
+        result = Image.for_gallery(category_ids: [cat.id], limit: 10)
+        expect(result.map(&:title)).to eq(%w[F2 C])
+      end
+    end
+  end
+
+  describe 'featured curation' do
+    describe '#feature!' do
+      it 'appends to the end of the featured list' do
+        existing = create(:image, :featured, featured_rank: 0)
+        image = create(:image)
+
+        image.feature!
+
+        expect(image.reload.featured_rank).to eq(1)
+        expect(existing.reload.featured_rank).to eq(0)
+      end
+
+      it 'is a no-op when already featured' do
+        image = create(:image, :featured, featured_rank: 0)
+        other = create(:image, :featured, featured_rank: 1)
+
+        image.feature!
+
+        expect(image.reload.featured_rank).to eq(0)
+        expect(other.reload.featured_rank).to eq(1)
+      end
+    end
+
+    describe '#unfeature!' do
+      it 'clears the rank and renormalizes the rest to 0..N-1' do
+        a = create(:image, :featured, featured_rank: 0)
+        b = create(:image, :featured, featured_rank: 1)
+        c = create(:image, :featured, featured_rank: 2)
+
+        b.unfeature!
+
+        expect(b.reload.featured_rank).to be_nil
+        expect(a.reload.featured_rank).to eq(0)
+        expect(c.reload.featured_rank).to eq(1)
+      end
+
+      it 'is a no-op when not featured' do
+        image = create(:image)
+
+        expect { image.unfeature! }.not_to(change { image.reload.featured_rank })
+      end
+    end
+
+    describe '.reorder_featured!' do
+      it 'normalizes the given ids to 0..N-1 in the given order' do
+        a = create(:image, :featured, featured_rank: 0)
+        b = create(:image, :featured, featured_rank: 1)
+        c = create(:image, :featured, featured_rank: 2)
+
+        Image.reorder_featured!([c.id, a.id, b.id])
+
+        expect(c.reload.featured_rank).to eq(0)
+        expect(a.reload.featured_rank).to eq(1)
+        expect(b.reload.featured_rank).to eq(2)
+      end
+
+      it 'leaves images not included untouched' do
+        a = create(:image, :featured, featured_rank: 0)
+        b = create(:image, :featured, featured_rank: 1)
+
+        Image.reorder_featured!([a.id])
+
+        expect(a.reload.featured_rank).to eq(0)
+        expect(b.reload.featured_rank).to eq(1)
+      end
+
+      it 'fails loudly when an id is unknown' do
+        a = create(:image, :featured, featured_rank: 0)
+
+        expect { Image.reorder_featured!([a.id, 0]) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end

--- a/backend/spec/requests/admin/image_bulk_updates_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_updates_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe 'Admin::ImageBulkUpdates', type: :request do
   include Devise::Test::IntegrationHelpers
 
   let(:user) { create(:user, :admin) }
-  let!(:image1) { create(:image, title: 'Test Image 1', row_order: 100) }
-  let!(:image2) { create(:image, title: 'Test Image 2', row_order: 200) }
-  let!(:image3) { create(:image, title: 'Test Image 3', row_order: 300) }
+  let!(:image1) { create(:image, title: 'Test Image 1') }
+  let!(:image2) { create(:image, title: 'Test Image 2') }
+  let!(:image3) { create(:image, title: 'Test Image 3') }
   let(:camera) { create(:camera) }
   let(:lens) { create(:lens) }
   let(:category) { create(:category) }

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -7,16 +7,17 @@ RSpec.describe 'Admin::Images', type: :request do
 
   # NOTE: id を固定して create すると PG のシーケンスが進まず、
   # 以降の自動採番 create が duplicate key で落ちるため自動採番に任せる。
-  let!(:image1) { create(:image, title: 'Test Image 1', row_order: 100) }
-  let!(:image2) { create(:image, title: 'Test Image 2', row_order: 200) }
-  let!(:image3) { create(:image, title: 'Test Image 3', row_order: 300) }
-  let!(:image4) { create(:image, title: 'Test Image 4', row_order: 400) }
+  # id 順が編集カードの ←/→ 遷移順にもなるため、作成順がそのままテストの前提になる。
+  let!(:image1) { create(:image, title: 'Test Image 1') }
+  let!(:image2) { create(:image, title: 'Test Image 2') }
+  let!(:image3) { create(:image, title: 'Test Image 3') }
+  let!(:image4) { create(:image, title: 'Test Image 4') }
 
   before { sign_in user }
 
   describe 'GET /admin/images' do
     it 'renders and surfaces the uncurated draft count with a filter link' do
-      create(:image, :draft, row_order: 500)
+      create(:image, :draft)
 
       get '/admin/images'
 
@@ -33,7 +34,7 @@ RSpec.describe 'Admin::Images', type: :request do
     end
 
     it 'filters to uncurated drafts only' do
-      draft = create(:image, :draft, row_order: 500)
+      draft = create(:image, :draft)
 
       get '/admin/images', params: { filter: 'uncurated' }
 
@@ -43,23 +44,27 @@ RSpec.describe 'Admin::Images', type: :request do
   end
 
   describe 'GET /admin/images/arrange' do
-    it 'lists only published images for reordering' do
-      draft = create(:image, :draft, row_order: 500)
+    it 'lists only featured images for reordering' do
+      featured = create(:image, :featured, featured_rank: 0)
+      draft = create(:image, :draft)
 
       get '/admin/images/arrange'
 
       expect(response).to have_http_status(:success)
-      expect(response.body).to include("data-image-id='#{image1.id}'").or include("data-image-id=\"#{image1.id}\"")
-      # 下書きは並び替え画面に出さない（公開ギャラリーの鏡）
-      expect(response.body).not_to include("data-image-id='#{draft.id}'")
-      expect(response.body).not_to include("data-image-id=\"#{draft.id}\"")
+      expect(response.body)
+        .to include("data-image-id='#{featured.id}'").or include("data-image-id=\"#{featured.id}\"")
+      # 下書き・非 featured の公開画像は並び替え画面に出さない（featured のみの鏡）
+      [draft, image1].each do |image|
+        expect(response.body).not_to include("data-image-id='#{image.id}'")
+        expect(response.body).not_to include("data-image-id=\"#{image.id}\"")
+      end
     end
   end
 
   describe 'GET /admin/images publish status column' do
     it 'shows status badges without inline publish/unpublish buttons' do
-      create(:image, :draft, title: 'Curated Draft', taken_at: 1.day.ago, row_order: 500)
-      uncurated = create(:image, :draft, taken_at: nil, row_order: 600)
+      create(:image, :draft, title: 'Curated Draft', taken_at: 1.day.ago)
+      uncurated = create(:image, :draft, taken_at: nil)
 
       get '/admin/images'
 
@@ -89,10 +94,17 @@ RSpec.describe 'Admin::Images', type: :request do
 
       expect(Image.order(:id).last).to have_attributes(title: 'New Published', is_published: true)
     end
+
+    it 'features the new image when the featured checkbox is checked' do
+      post '/admin/images',
+           params: { image: { title: 'New Featured', file: file, is_featured: '1' } }
+
+      expect(Image.order(:id).last.featured_rank).to eq(0)
+    end
   end
 
   describe 'PATCH /admin/images/:id (publish via submit buttons)' do
-    let!(:draft) { create(:image, :draft, row_order: 500) }
+    let!(:draft) { create(:image, :draft) }
 
     it 'publishes with 公開する and stays on the card' do
       patch "/admin/images/#{draft.id}",
@@ -120,8 +132,34 @@ RSpec.describe 'Admin::Images', type: :request do
     end
   end
 
+  describe 'PATCH /admin/images/:id (featured toggle)' do
+    it 'features the image when the checkbox is checked' do
+      patch "/admin/images/#{image1.id}", params: { image: { title: image1.title, is_featured: '1' } }
+
+      expect(image1.reload.featured_rank).to eq(0)
+    end
+
+    it 'unfeatures the image and renormalizes the rest when unchecked' do
+      image1.feature!
+      image2.feature!
+
+      patch "/admin/images/#{image1.id}", params: { image: { title: image1.title, is_featured: '0' } }
+
+      expect(image1.reload.featured_rank).to be_nil
+      expect(image2.reload.featured_rank).to eq(0)
+    end
+
+    it 'leaves the featured state untouched when the field is not submitted' do
+      image1.feature!
+
+      patch "/admin/images/#{image1.id}", params: { image: { title: 'Renamed only' } }
+
+      expect(image1.reload.featured_rank).to eq(0)
+    end
+  end
+
   describe 'PATCH /admin/images/:id (card navigation)' do
-    it 'saves and moves to the next image in display order with 次へ' do
+    it 'saves and moves to the next image in id order with 次へ' do
       patch "/admin/images/#{image2.id}", params: { nav_next: '次へ →', image: { title: 'Renamed' } }
 
       expect(image2.reload.title).to eq('Renamed')
@@ -151,39 +189,30 @@ RSpec.describe 'Admin::Images', type: :request do
   end
 
   describe 'POST /admin/images/:id/insert_at' do
-    it 'should insert the image at the given position' do
-      expect(Image.rank(:row_order).pluck(:id)).to eq([image1.id, image2.id, image3.id, image4.id])
+    let!(:f1) { create(:image, :featured, title: 'F1', featured_rank: 0) }
+    let!(:f2) { create(:image, :featured, title: 'F2', featured_rank: 1) }
+    let!(:f3) { create(:image, :featured, title: 'F3', featured_rank: 2) }
 
-      post "/admin/images/#{image1.id}/insert_at", params: { position: 2 }
+    it 'moves the image to the given position within the featured list' do
+      post "/admin/images/#{f1.id}/insert_at", params: { position: 2 }
       expect(response).to have_http_status(:success)
 
-      expect(Image.rank(:row_order).pluck(:id)).to eq([image2.id, image3.id, image1.id, image4.id])
+      expect(Image.featured.pluck(:id)).to eq([f2.id, f3.id, f1.id])
     end
 
-    it 'translates a published-list index into a global position, stepping over an interleaved draft' do
-      # global順: image1(100) < draft(150) < image2(200) < image3(300) < image4(400)
-      draft = create(:image, :draft, taken_at: nil, row_order: 150)
-
-      # 公開リスト [image1, image2, image3, image4] の index 1 へ image4 を移動
-      post "/admin/images/#{image4.id}/insert_at", params: { position: 1 }
+    it 'moves the image to the front of the featured list' do
+      post "/admin/images/#{f3.id}/insert_at", params: { position: 0 }
       expect(response).to have_http_status(:success)
 
-      # draft は image1 の直後に留まり、image4 は image2 の直前へ入る
-      expect(Image.rank(:row_order).pluck(:id))
-        .to eq([image1.id, draft.id, image4.id, image2.id, image3.id])
+      expect(Image.featured.pluck(:id)).to eq([f3.id, f1.id, f2.id])
     end
 
-    it 'drops to the tail of the published list without overtaking a trailing draft' do
-      # 末尾の公開画像より後ろに滞留する下書き
-      draft = create(:image, :draft, taken_at: nil, row_order: 500)
-
-      # 公開リスト末尾（index 3）へ image1 を移動
-      post "/admin/images/#{image1.id}/insert_at", params: { position: 3 }
+    it 'does not touch images outside the featured set' do
+      post "/admin/images/#{f1.id}/insert_at", params: { position: 1 }
       expect(response).to have_http_status(:success)
 
-      # image1 は最後の公開画像 image4 の直後、末尾の draft の前に入る
-      expect(Image.rank(:row_order).pluck(:id))
-        .to eq([image2.id, image3.id, image4.id, image1.id, draft.id])
+      expect(image1.reload.featured_rank).to be_nil
+      expect(image2.reload.featured_rank).to be_nil
     end
   end
 

--- a/backend/spec/requests/api/images_spec.rb
+++ b/backend/spec/requests/api/images_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe 'Images API', type: :request do
   let(:cdn_base_url) { ENV.fetch('CLOUDFRONT_BASE_URL', nil) }
 
   before do
-    create(:image, title: 'Test Image 1', id: 1, row_order: 0)
-    create(:image, title: 'Test Image 2', row_order: 1)
+    create(:image, title: 'Test Image 1', id: 1, taken_at: 1.day.ago)
+    create(:image, title: 'Test Image 2', taken_at: 2.days.ago)
     create(:image, title: 'Test Image unpublished', is_published: false)
-    create(:image, title: 'Test Image with category 1', row_order: 2,
+    create(:image, title: 'Test Image with category 1', taken_at: 3.days.ago,
                    categories: [create(:category, name: 'Test Category 1', id: 1)])
-    create(:image, title: 'Test Image with category 2', row_order: 3,
+    create(:image, title: 'Test Image with category 2', taken_at: 4.days.ago,
                    categories: [create(:category, name: 'Test Category 2', id: 2)])
   end
 
@@ -96,7 +96,7 @@ RSpec.describe 'Images API', type: :request do
         expect(first_page_titles & second_page_titles).to be_empty
       end
 
-      it 'returns images ordered by row_order and id' do
+      it 'returns images ordered by taken_at desc and id desc' do
         get '/api/images'
         titles = response.parsed_body['images'].pluck('title')
 
@@ -116,8 +116,8 @@ RSpec.describe 'Images API', type: :request do
       it 'applies cursor with category filter' do
         # Create extra images for the same category so we can paginate
         cat = Category.find(1)
-        create(:image, title: 'Cat1 Extra 1', row_order: 4, categories: [cat])
-        create(:image, title: 'Cat1 Extra 2', row_order: 5, categories: [cat])
+        create(:image, title: 'Cat1 Extra 1', taken_at: 5.days.ago, categories: [cat])
+        create(:image, title: 'Cat1 Extra 2', taken_at: 6.days.ago, categories: [cat])
 
         get '/api/images', params: { categories: '1', limit: 1 }
         first_page = response.parsed_body
@@ -130,6 +130,32 @@ RSpec.describe 'Images API', type: :request do
 
         expect(second_page['images'].length).to eq(2)
         expect(second_page['has_more']).to be false
+      end
+    end
+
+    context 'featured pinning' do
+      let!(:featured) { create(:image, :featured, title: 'Featured 1', featured_rank: 0, taken_at: 10.days.ago) }
+
+      it 'lists featured images first without duplicating them in the timeline' do
+        get '/api/images', params: { limit: 10 }
+        titles = response.parsed_body['images'].pluck('title')
+
+        expect(titles.first).to eq('Featured 1')
+        expect(titles.count('Featured 1')).to eq(1)
+      end
+
+      it 'round-trips a cursor across the featured -> timeline segment boundary' do
+        get '/api/images', params: { limit: 1 }
+        first_page = response.parsed_body
+
+        expect(first_page['images'].pluck('title')).to eq(['Featured 1'])
+        expect(first_page['next_cursor']).to match(/\Af,/)
+
+        get '/api/images', params: { limit: 10, cursor: first_page['next_cursor'] }
+        second_page = response.parsed_body
+
+        expect(second_page['images'].pluck('title')).not_to include('Featured 1')
+        expect(second_page['images'].length).to eq(4)
       end
     end
   end


### PR DESCRIPTION
## 概要
公開ギャラリーの基本並び順を row_order（全件手動）から taken_at 降順（自動）に変え、手動キュレーションは featured_rank（ギャラリー先頭に pin、〜50枚想定）だけに縮小する。ranked-model と row_order は削除。

Closes #273

## レビュー優先度
🔴 全文レビュー — スキーマ変更 + 公開 API のページネーション再実装

## 判断・トレードオフ
- **cursor は2セグメント keyset の自己記述形式**（`f,<rank>,<id>` / `t,<taken_at_ms>,<id>`）: featured→時系列の境界をまたぐページングを、複合ソート1本の複雑な keyset にせず2クエリの継ぎ足しで実装。featured は時系列側に重複して出さない
- **taken_at のミリ秒丸めは round ではなく floor**: round だと切り上げで cursor が行の実精度より未来になり、次ページに自分自身が再出現する（spec で検出した実バグ）。残る理論的エッジは「同一ミリ秒内に異なるサブミリ秒精度の taken_at が並ぶ」場合のみで、EXIF/フォーム由来の taken_at は秒精度のため実運用では発生しない
- **featured 操作ロジックは `ImageGalleryOrdering` concern に集約**（既存 `CdnAttachedFile` と同じ構成パターン）
- **featured トグルは編集フォームのチェックボックス**（`is_featured` 仮想属性）: 公開トグルが編集画面に集約されている既存の流儀に合わせた
- **admin 画像一覧と curation flow の prev/next は id 順**: draft は taken_at を持たないことがあるため
- arrange 画面は featured のみ表示になり、published index→row_order 変換ロジック（`published_index_to_row_order_position`）は丸ごと削除

## 確認
- `bundle exec rspec` 159 examples / 0 failures、`bundle exec rubocop` offenses なし（いずれも exit code で確認）
- セグメント境界をまたぐページング・カテゴリ絞り込み×featured・重複非表示・cursor round-trip・feature/unfeature 正規化を spec で実経路を踏ませて確認
- マイグレーションは `db:prepare` で適用確認（実データ投入前のため row_order のデータ移行なし）
- arrange 画面・編集フォームの実描画は未確認（作者レビュー時に手動確認予定）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)