### PR TITLE
fix: コード品質改善 - Devise登録制限・file_url可視性・JSON-LDエスケープ

### DIFF
--- a/backend/app/controllers/users/registrations_controller.rb
+++ b/backend/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,15 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :block_new_registration, only: %i[new create]
+  def new
+    render_not_found
+  end
+
+  def create
+    render_not_found
+  end
 
   private
 
-  def block_new_registration
+  def render_not_found
     render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
   end
 end

--- a/backend/app/controllers/users/registrations_controller.rb
+++ b/backend/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,9 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :block_new_registration, only: %i[new create]
+
+  private
+
+  def block_new_registration
+    render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
+  end
+end

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -23,18 +23,18 @@ module CdnAttachedFile
   # variants-before-save の順序保証はここに集約する（Image は EXIF 補完を差し込む）。
   def after_attached_file_processed; end
 
-  def file_url
-    return unless file.attached?
-
-    build_cdn_url(file.key) || active_storage_url_for(file)
-  end
-
   def thumbnail_variant = variant_for(thumbnail_limit)
 
   def thumbnail_url = variant_url(thumbnail_limit)
   def display_url = variant_url(display_limit)
 
   private
+
+  def file_url
+    return unless file.attached?
+
+    build_cdn_url(file.key) || active_storage_url_for(file)
+  end
 
   def variant_for(limit)
     return unless file.attached?

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'users/registrations' }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -51,10 +51,11 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  # file_url は variant_url のフォールバック専用の private ヘルパーなので send で検証する。
   describe '#file_url' do
     context 'when file is not attached' do
       it 'returns nil' do
-        expect(project.file_url).to be_nil
+        expect(project.send(:file_url)).to be_nil
       end
     end
 
@@ -63,7 +64,7 @@ RSpec.describe Project, type: :model do
         file = double('ActiveStorage::Attached::One', attached?: true, key: 'projects/file-key')
         allow(project).to receive(:file).and_return(file)
 
-        expect(project.file_url).to eq("#{cdn_base_url}/projects/file-key")
+        expect(project.send(:file_url)).to eq("#{cdn_base_url}/projects/file-key")
       end
     end
   end

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify([personJsonLd, websiteJsonLd]),
+            __html: JSON.stringify([personJsonLd, websiteJsonLd]).replace(/</g, '\\u003c'),
           }}
         />
         {children}


### PR DESCRIPTION
## 概要

定期コード品質チェック（2026-07-10）で発見した問題の修正。

## 変更内容

### 1. Devise 公開登録エンドポイントのブロック
- **問題**: `devise_for :users` の `:registerable` が有効なまま放置されており、`POST /users/sign_up` が認証不要で公開されていた。ポートフォリオ管理サイトとして不特定多数のユーザー登録を許可すべきでない
- **修正**: `Users::RegistrationsController` を新設し、`new`/`create` アクションを 404 で返すようにした。既存の管理者ユーザーによる認証情報編集（`edit`/`update`）は引き続き動作する
- **ファイル**: `config/routes.rb`, `app/controllers/users/registrations_controller.rb`

### 2. `CdnAttachedFile#file_url` を private に移動
- **問題**: `file_url` が `private` 宣言より前に定義されており、意図せず public メソッドになっていた。このメソッドは `variant_url` のフォールバックとして内部使用のみを想定している
- **修正**: `private` セクション内に移動
- **ファイル**: `app/models/concerns/cdn_attached_file.rb`

### 3. JSON-LD script タグの `</script>` エスケープ
- **問題**: `layout.tsx` で `dangerouslySetInnerHTML` + `JSON.stringify` を使用しており、文字列に `</script>` が含まれると HTML パーサーがスクリプトタグを途中で閉じてしまう可能性があった（現状は静的データのため非 exploitable だが防御的改善）
- **修正**: `.replace(/</g, '\\u003c')` を追加し、JSON 出力中の `<` を Unicode エスケープに変換
- **ファイル**: `frontend/src/app/layout.tsx`

## 報告のみ（今回の PR には含まない）

| # | 問題 | 場所 | リスク |
|---|------|------|--------|
| 4 | `articles`/`publishments` テーブルがスキーマにあるがモデルファイルが存在しない（ブログ機能の残骸と思われる） | `db/schema.rb` | 低（DBの不要な重み） |
| 5 | 公開 API エンドポイントにレート制限がない（`rack-attack` 等なし） | `config/initializers/` | 低〜中（DDoS耐性） |


---
_Generated by [Claude Code](https://claude.ai/code/session_0123pcb5dWMiWgereEqVCWeM)_