### PR TITLE
docs(agents): AGENTS.md のバージョン情報・テスト情報を現状に合わせて修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 ## Project Structure
 
-- `backend/` — Rails 7.2 API + admin UI (Ruby 3.3.5)
-- `frontend/` — Next.js 15 + React 19 (TypeScript, Tailwind, Yarn 4)
+- `backend/` — Rails 8.1 API + admin UI (Ruby 3.3.5)
+- `frontend/` — Next.js 16 + React 19 (TypeScript, Tailwind, Yarn 4)
 - `docker-compose.yml` / `docker-compose.prod.yml` — 開発・本番環境
-- `.github/workflows/` — CI (`backend.yml`, `frontend.yml`)
+- `.github/workflows/` — CI (`backend.yml`, `frontend.yml`, `e2e.yml`)
 
 ## Commands
 
@@ -38,7 +38,7 @@ yarn tsc --noEmit            # 型チェック
 ## Testing
 
 - Backend: RSpec (`backend/spec/`)。ファクトリは `backend/spec/factories/`。
-- Frontend: テストフレームワーク未導入。
+- Frontend: Vitest + Testing Library (`frontend/src/**/*.test.{ts,tsx}`)。`yarn test` で実行。
 
 ## Commit & PR
 


### PR DESCRIPTION
## 変更概要

AGENTS.md に記載されていた技術スタック情報が実際のコードと乖離していたため、現状に合わせて修正しました。

## 修正内容

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| Rails バージョン | Rails 7.2 | Rails 8.1 |
| Next.js バージョン | Next.js 15 | Next.js 16 |
| CI ワークフロー | `backend.yml`, `frontend.yml` | `backend.yml`, `frontend.yml`, `e2e.yml` |
| フロントエンドテスト | テストフレームワーク未導入 | Vitest + Testing Library (`yarn test`) |

## 背景

コード品質チェック (2026-07-13) の一環として AGENTS.md を確認したところ、以下の誤りが見つかりました。

- `Gemfile` には `gem 'rails', '~> 8.1'` と記載されているが、AGENTS.md は 7.2 のまま
- `frontend/package.json` の next バージョンは `^16.2.10` だが、AGENTS.md は 15 のまま
- `.github/workflows/e2e.yml` が存在するが CI 一覧に未記載
- Vitest + Testing Library が導入済み (`frontend/src/**/*.test.{ts,tsx}` に 6 ファイル) だが「テストフレームワーク未導入」と誤記

AGENTS.md は AI エージェントや開発者がプロジェクト構成を把握するための重要なドキュメントのため、正確な情報に更新しました。

## 関連

- コード品質チェック自動実行 (2026-07-13)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETaRsACeEXMrkUhyy2nSrn)_