### PR TITLE
fix(backend): e2e seed の skip_callback を新コールバック名に追従

### DIFF
--- a/backend/lib/tasks/e2e.rake
+++ b/backend/lib/tasks/e2e.rake
@@ -55,9 +55,10 @@ def seed_project
 end
 
 def suppress_cdn_callbacks
+  # 添付後処理は本番では Solid Queue に退避される（cdn_attached_file 参照）。
+  # seed では job を回さず analyze_and_warm_variants で同期処理するため無効化する。
   [Image, Project].each do |klass|
-    klass.skip_callback(:commit, :after, :warm_variants)
-    klass.skip_callback(:commit, :after, :analyze_attached_file)
+    klass.skip_callback(:commit, :after, :enqueue_attached_file_processing)
   end
 end
 


### PR DESCRIPTION
## 概要

main の E2E Tests（および Deploy）が seed 段階で落ちていた問題の修正。

## 原因

`#271`（添付ファイル後処理の Solid Queue 非同期化）で、旧 after_commit コールバック `warm_variants` / `analyze_attached_file` は単一の `enqueue_attached_file_processing` に統合された。しかし `lib/tasks/e2e.rake` の `suppress_cdn_callbacks` が旧コールバック名を `skip_callback` しようとしていたため、seed 実行時に次で落ちていた:

```
ArgumentError: After commit callback :warm_variants has not been defined
```

E2E は main への push でのみ実行される（PR では走らない）ため、マージ時点では検出されなかった。

## 修正

`suppress_cdn_callbacks` を新コールバック名 `enqueue_attached_file_processing` 1 本に更新。

## 確認

- `RAILS_ENV=test bin/rails runner` で該当 `skip_callback` が解決することを確認
- rubocop 通過
- E2E 本体はマージ後の main push で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)