### PR TITLE
fix(backend): main の Deploy と E2E を復旧（require_master_key / featured seed）

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -18,7 +18,9 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
-  config.require_master_key = true
+  # Docker の assets:precompile は master.key を持たず SECRET_KEY_BASE_DUMMY=1 で boot するため、
+  # そのビルド時のみ緩め、実行時（runtime）は従来どおり master key を必須にする。
+  config.require_master_key = ENV["SECRET_KEY_BASE_DUMMY"].blank?
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
   # config.public_file_server.enabled = false

--- a/backend/lib/tasks/e2e.rake
+++ b/backend/lib/tasks/e2e.rake
@@ -30,12 +30,15 @@ def seed_images(camera, lens, category)
 
   test_image_path = Rails.root.join('spec/fixtures/files/test_image.jpg')
 
+  # 並び替え画面（/admin/images/arrange）は featured のみ表示する（#273 の再設計）。
+  # arrange の e2e が Seed Image 1..3 を掴めるよう featured_rank を昇順で付与する。
   3.times do |i|
     image = Image.new(
       title: "Seed Image #{i + 1}",
       caption: "E2E test image #{i + 1}",
       taken_at: Time.zone.today - i.days,
       is_published: true,
+      featured_rank: i,
       camera: camera,
       lens: lens
     )


### PR DESCRIPTION
## 概要

main で継続的に落ちていた **Deploy** と **E2E Tests** を復旧する。どちらも PR では走らず main への push でのみ実行されるため、マージ後に顕在化していた。

## 1. Deploy 失敗（backend build: `Missing encryption key`）

- **原因**: #270 で `config.require_master_key = true` を有効化。master.key を持たない Docker ビルドの `assets:precompile` は `SECRET_KEY_BASE_DUMMY=1` で boot するが、これは `secret_key_base` しか肩代わりせず、master key 必須チェックに引っかかり `Missing encryption key` で build が落ちていた（last green は #274、first red は #270 マージ）。
- **修正**: `config.require_master_key = ENV["SECRET_KEY_BASE_DUMMY"].blank?`。ビルド時（DUMMY=1）のみ false、runtime（DUMMY 無し）は従来どおり必須。
- **検証**: master.key を退避し、`DUMMY=1` では boot 成功・`require_master_key=false` / `DUMMY` 無しでは `Missing encryption key` で拒否されることを確認。

## 2. E2E 失敗（`admin/a-image-sort.spec.ts`）

- **原因1（seed 段階）**: 既に #293 で修正済み（旧 after_commit 名 `warm_variants` を skip していた ArgumentError）。
- **原因2（本 PR）**: #273/#281 で並び替え画面 `/admin/images/arrange` が **featured 画像のみ表示**に再設計されたが、e2e seed は featured 指定していないため arrange が 0 件になり、`tr[data-image-id]` を掴めず失敗していた。
- **修正**: seed 3枚に `featured_rank` 0,1,2 を付与。
- **検証**: `RAILS_ENV=test bin/rails e2e:seed` 実行で `Image.featured` が `["Seed Image 1","Seed Image 2","Seed Image 3"]` の順に3件生成されることを確認。

## 確認方針

E2E / Deploy 本体はマージ後の main push で最終確認する（PR では走らないため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)