### PR TITLE
fix(compose): Traefik 接続を homelab の規約（SSOT）に合わせる

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,5 @@ PGHOST=DB
 AWS_ACCESS_KEY_ID=<REPLACE_ME>
 AWS_SECRET_ACCESS_KEY=<REPLACE_ME>
 CLOUDFRONT_BASE_URL=https://your-distribution.cloudfront.net
+# 共有 Traefik のホスト名（規約: homelab/local/traefik/README.md）。デフォルトで動くので通常は不要
+# DOMAIN=portfolio.localhost

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,11 @@
 # ローカル Traefik（homelab/local/traefik）経由のルーティング層
-# - frontend: http://portfolio.localhost
-# - backend:  http://api.portfolio.localhost
-# 既存の ports 公開（localhost:3002 / :3000）はそのまま残る（e2e 等の互換用）
+# 接続規約（SSOT）: https://github.com/huji333/homelab/blob/main/local/traefik/README.md
+# - frontend: http://${DOMAIN:-portfolio.localhost}
+# - backend:  http://api.${DOMAIN:-portfolio.localhost}
+# staging へは DOMAIN=portfolio.apps.home.arpa に差し替えるだけで載る
+#
+# 本体 compose の host ports 公開（localhost:3000 / :3002）は規約 #5 の例外:
+# e2e（Playwright）が localhost を直叩きするため互換用に残している
 services:
   backend:
     networks:
@@ -9,22 +13,22 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.http.routers.portfolio-api.rule=Host(`api.portfolio.localhost`)
+      - traefik.http.routers.portfolio-api.rule=Host(`api.${DOMAIN:-portfolio.localhost}`)
       - traefik.http.services.portfolio-api.loadbalancer.server.port=3000
     environment:
-      FRONTEND_ORIGIN: 'http://portfolio.localhost'
+      FRONTEND_ORIGIN: 'http://${DOMAIN:-portfolio.localhost}'
       # Rails HostAuthorization に Traefik 経由のホスト名を許可させる（development のみ有効な標準 env）
-      RAILS_DEVELOPMENT_HOSTS: 'api.portfolio.localhost'
+      RAILS_DEVELOPMENT_HOSTS: 'api.${DOMAIN:-portfolio.localhost}'
   frontend:
     networks:
       - default
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.http.routers.portfolio.rule=Host(`portfolio.localhost`)
+      - traefik.http.routers.portfolio.rule=Host(`${DOMAIN:-portfolio.localhost}`)
       - traefik.http.services.portfolio.loadbalancer.server.port=3002
     environment:
-      NEXT_PUBLIC_API_BASE_URL: 'http://api.portfolio.localhost/api'
+      NEXT_PUBLIC_API_BASE_URL: 'http://api.${DOMAIN:-portfolio.localhost}/api'
 
 networks:
   traefik:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./backend/.env.development
     volumes:
       - ./backend:/app
+    # e2e（Playwright）が localhost:3000 を直叩きするため互換用に公開を維持
     ports:
       - '3000:3000'
     environment:
@@ -31,6 +32,7 @@ services:
     # 依存を bump しても volume が stale 化して `command not found: next` を起こす。
     # 起動時 install で volume を自己修復するキャッシュにし、volume の手動削除を不要にする。
     command: sh -c "yarn install --immutable && yarn dev"
+    # e2e（Playwright）が localhost:3002 を直叩きするため互換用に公開を維持
     ports:
       - '3002:3002'
     environment:


### PR DESCRIPTION
## 概要
homelab の共有 Traefik 接続規約（[local/traefik/README.md](https://github.com/huji333/homelab/blob/main/local/traefik/README.md)）に準拠し、ホスト名を `DOMAIN` env var に外部化した。

Closes #295

## レビュー優先度
🟡 動作確認のみ — 設定変更のみで、`DOMAIN` 未設定時の解決値は変更前と完全に同一（`docker compose config` で確認済み）

## 判断・トレードオフ
- `FRONTEND_ORIGIN` / `RAILS_DEVELOPMENT_HOSTS` / `NEXT_PUBLIC_API_BASE_URL` も同じ `DOMAIN` から導出し、ホスト名の真実を1変数に集約（規約 #2 + single-source）
- 互換用 host ports（3000/3002）は base compose に残置し、移動ではなくコメント明記を選択（issue の指定どおり）。e2e（Playwright）が localhost を直叩きしており、CI は compose 不使用・ローカル e2e 手順は `--service-ports` で override 込みマージのため影響なし
- router/service 名（`portfolio` / `portfolio-api`）は既に規約 #1 準拠のため変更なし

## 確認
- `docker compose config` で DOMAIN 未設定（`portfolio.localhost`）/ staging 想定（`DOMAIN=portfolio.apps.home.arpa`）の両方でラベル・env が正しく展開されることを確認
- 実環境で http://portfolio.localhost と http://api.portfolio.localhost/api/images が 200、Traefik API 上で `portfolio` / `portfolio-api` 両 router が enabled であることを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)