### PR TITLE
fix(frontend): projects API 境界で tags 欠落を正規化し ProjectCard のランタイムエラーを防ぐ

### DIFF
--- a/frontend/src/hooks/projectApi.test.ts
+++ b/frontend/src/hooks/projectApi.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchProjects } from './projectApi';
+
+vi.mock('@/utils/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/utils/api';
+const mockApiFetch = vi.mocked(apiFetch);
+
+const baseProject = {
+  id: 1,
+  title: 'Project',
+  link: 'https://example.com',
+  description: null,
+  file: null,
+};
+
+describe('fetchProjects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes missing tags to an empty array', async () => {
+    mockApiFetch.mockResolvedValue({ data: [{ ...baseProject }], error: false });
+
+    const result = await fetchProjects();
+    expect(result).toEqual({
+      projects: [{ ...baseProject, tags: [] }],
+      error: false,
+    });
+  });
+
+  it('keeps tags as-is when present', async () => {
+    mockApiFetch.mockResolvedValue({
+      data: [{ ...baseProject, tags: ['a', 'b'] }],
+      error: false,
+    });
+
+    const result = await fetchProjects();
+    expect(result).toEqual({
+      projects: [{ ...baseProject, tags: ['a', 'b'] }],
+      error: false,
+    });
+  });
+
+  it('returns empty projects on error', async () => {
+    mockApiFetch.mockResolvedValue({ data: null, error: true });
+
+    const result = await fetchProjects();
+    expect(result).toEqual({ projects: [], error: true });
+  });
+});

--- a/frontend/src/hooks/projectApi.ts
+++ b/frontend/src/hooks/projectApi.ts
@@ -10,9 +10,17 @@ type FetchProjectsResult = {
   error: boolean;
 };
 
+// migration 未適用の DB では as_json が tags キー自体を省略するため、
+// レスポンス上は tags が存在しないケースを型として許容し、正規化する。
+type ProjectResponse = Omit<ProjectType, 'tags'> & { tags?: string[] };
+
 export async function fetchProjects({
   fetchInit,
 }: FetchProjectsOptions = {}): Promise<FetchProjectsResult> {
-  const result = await apiFetch<ProjectType[]>('/projects', 'projects', fetchInit);
-  return { projects: result.error ? [] : result.data, error: result.error };
+  const result = await apiFetch<ProjectResponse[]>('/projects', 'projects', fetchInit);
+  if (result.error) {
+    return { projects: [], error: true };
+  }
+  const projects = result.data.map((project) => ({ ...project, tags: project.tags ?? [] }));
+  return { projects, error: false };
 }


### PR DESCRIPTION
## 概要
migration 未適用の DB では backend の `as_json(only:)` が `tags` キーを黙って省略し、`ProjectCard.tsx` の `project.tags.length` が undefined エラーでクラッシュするため、`fetchProjects` の API 境界で `tags ?? []` に正規化する。

Closes #278

## レビュー優先度
🔴 全文レビュー — 公開側のロジック変更（API レスポンス正規化）

## 判断・トレードオフ
- 防御は API 境界（`projectApi.ts`）の1箇所のみに置き、コンポーネント側にはガードを重ねない（single-source）。`ProjectType.tags: string[]` は変えず、レスポンス受け取り型だけ `tags?: string[]` で受けて正規化する
- backend は修正しない。本番 DB は `default: [], null: false` のため現状発症せず、drift の発生源は dev DB の migration 遅れ

## 確認
- `yarn lint` / `yarn test` exit 0（Test Files 7 passed / Tests 31 passed、新規3件含む: tags 欠落→`[]` 正規化・tags あり→そのまま・error 時→空配列）
- 実ブラウザでの描画確認は未実施（表示ロジック自体は不変のため、既存描画への影響はテストで担保）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)