### PR TITLE
feat(frontend): gallery/projects の空状態メッセージを追加

### DIFF
--- a/frontend/src/app/gallery/_components/GalleryApp.test.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GalleryApp from './GalleryApp';
+import { ImageType } from '@/utils/types';
+
+const image: ImageType = {
+  id: 1,
+  title: 'Mountain',
+  caption: null,
+  taken_at: null,
+  camera_name: null,
+  lens_name: null,
+  file: '/mountain.jpg',
+  thumbnail: '/mountain-thumb.jpg',
+  width: 800,
+  height: 600,
+};
+
+describe('GalleryApp', () => {
+  it('shows empty state message when there are no images', () => {
+    render(<GalleryApp />);
+    expect(screen.getByText('表示できる写真がまだありません。')).toBeInTheDocument();
+  });
+
+  it('does not show empty state message when initialImages is provided', () => {
+    render(<GalleryApp initialImages={[image]} />);
+    expect(screen.queryByText('表示できる写真がまだありません。')).not.toBeInTheDocument();
+  });
+
+  it('shows fetch error message and not the empty state message when initialFetchError is true', () => {
+    render(<GalleryApp initialFetchError />);
+    expect(screen.getByText('読み込みに失敗しました。')).toBeInTheDocument();
+    expect(screen.queryByText('表示できる写真がまだありません。')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -141,6 +141,9 @@ export default function GalleryApp({
       {fetchError && (
         <p className="text-center text-sm text-red-600">読み込みに失敗しました。</p>
       )}
+      {!isLoadingImages && !fetchError && images.length === 0 && (
+        <p className="text-center text-sm text-foreground">表示できる写真がまだありません。</p>
+      )}
       <ImageGrid
         images={images}
         isLoading={isLoadingImages}

--- a/frontend/src/app/projects/_components/ProjectApp.tsx
+++ b/frontend/src/app/projects/_components/ProjectApp.tsx
@@ -11,6 +11,9 @@ export default async function ProjectApp() {
       {error && (
         <p className="mb-4 text-center text-sm text-red-600">読み込みに失敗しました。</p>
       )}
+      {!error && projects.length === 0 && (
+        <p className="mb-4 text-center text-sm text-foreground">表示できるプロジェクトがまだありません。</p>
+      )}
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {projects.map((project) => (
           <ProjectCard key={project.id} project={project} />


### PR DESCRIPTION
## 概要
公開コンテンツが 0 件のとき `/gallery` と `/projects` が真っ白になるため、トップページと同じ文言の空状態メッセージを表示する（#200 の項目3。#200 全体はコンテンツ投入が残るため Closes にしない）。

Refs #200

## レビュー優先度
🔴 全文レビュー — 公開側の新規 UI 挙動

## 判断・トレードオフ
- 文言はトップページの `GallerySection` / `ProjectsSection` の既存文言に統一。カテゴリフィルタで 0 件の場合も同一メッセージ（文言分岐は YAGNI でスキップ）
- `ImageGrid` の「thumbnail/寸法欠落画像のサイレント非表示」は #240 管轄のためスコープ外

## 確認
- `yarn lint` / `yarn test` exit 0（Test Files 7 passed / Tests 31 passed、`GalleryApp.test.tsx` 新規3件: 0件で表示・画像ありで非表示・fetchError 時はエラーのみ）
- 実描画確認済み（dev で公開 0 件にして `/gallery` `/projects` を目視、2026-07-15）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)