### PR TITLE
feat(admin): バルク取込にサーバサイドのファイル検証を追加

### DIFF
--- a/backend/app/controllers/admin/image_bulk_imports_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_imports_controller.rb
@@ -1,6 +1,17 @@
 class Admin::ImageBulkImportsController < Admin::Base
   before_action :set_form_options
 
+  # Cloudflare Tunnel の無料プランには 1 リクエスト 100MB のハード上限があるため、
+  # それを超えないよう十分な余裕を持たせてアプリ側の上限をここに定義する。
+  MAX_FILE_SIZE = 50.megabytes
+
+  # vips が扱えるラスター形式のみ許可する。宣言された content_type と実バイト
+  # （マジックバイト）の両方がこの一覧に含まれる場合のみ画像として受理し、
+  # 偽装された Content-Type（実体は画像でないファイルが image/jpeg を名乗る等）を弾く。
+  ACCEPTED_CONTENT_TYPES = %w[
+    image/jpeg image/png image/webp image/heic image/heif image/tiff image/gif image/avif
+  ].freeze
+
   def new
     @results = nil
   end
@@ -61,6 +72,11 @@ class Admin::ImageBulkImportsController < Admin::Base
     blob = ActiveStorage::Blob.find_signed!(signed_id)
     filename = blob.filename.to_s
 
+    if (reason = blob_rejection_reason(blob))
+      blob.purge_later
+      return { filename: filename, status: :failed, image: nil, duplicate_image_id: nil, errors: [reason] }
+    end
+
     if (duplicate = Image.attached_duplicate_for(blob))
       blob.purge_later
       return { filename: filename, status: :duplicate, image: nil, duplicate_image_id: duplicate.id, errors: [] }
@@ -76,5 +92,24 @@ class Admin::ImageBulkImportsController < Admin::Base
   rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
     { filename: signed_id.to_s.truncate(24), status: :failed, image: nil, duplicate_image_id: nil,
       errors: ['アップロードが無効です（再アップロードしてください）'] }
+  end
+
+  # サイズは direct upload 時点でメタデータとして分かっているので blob.byte_size を見るだけで済む。
+  # 形式判定はサイズ超過より後回しにし、明らかに大きすぎるファイルでは byte range 取得すら行わない。
+  # 先頭 4KB だけを ranged GET で取得して Marcel にマジックバイト判定させる（S3 からのフルダウンロードは避ける）。
+  def blob_rejection_reason(blob)
+    return 'サイズ上限50MBを超えています' if blob.byte_size > MAX_FILE_SIZE
+
+    # declared_type は渡さない: Marcel は「マジックバイトで判定できない場合」に
+    # declared_type へフォールバックしてしまい、それでは偽装された Content-Type を
+    # そのまま信用することになる。ここではバイト由来の判定だけを独立して見る。
+    header = blob.download_chunk(0...(4.kilobytes))
+    detected_content_type = Marcel::MimeType.for(StringIO.new(header))
+
+    if ACCEPTED_CONTENT_TYPES.include?(blob.content_type) && ACCEPTED_CONTENT_TYPES.include?(detected_content_type)
+      return nil
+    end
+
+    '画像ではありません'
   end
 end

--- a/backend/app/views/admin/image_bulk_imports/new.html.haml
+++ b/backend/app/views/admin/image_bulk_imports/new.html.haml
@@ -19,6 +19,7 @@
   .mb-3
     = form.label :files, '画像ファイル（複数選択可）', class: 'col-form-label fw-bold'
     = form.file_field :files, multiple: true, direct_upload: true, accept: 'image/*', class: 'form-control', data: { direct_upload_target: "input" }
+    %small.text-muted.d-block.mt-1 対応形式: JPEG / PNG / WebP / HEIC・HEIF / TIFF / GIF / AVIF、1ファイルあたり50MBまで。それ以外は取り込みに失敗します。
   .progress.d-none.mb-3{ data: { direct_upload_target: "progress" } }
     .progress-bar.progress-bar-striped.progress-bar-animated.admin-progress-bar{ role: "progressbar", "aria-valuenow": "0", "aria-valuemin": "0", "aria-valuemax": "100" }
   .alert.alert-danger.d-none.mb-3{ data: { direct_upload_target: "error" } }

--- a/backend/spec/fixtures/files/not_an_image.txt
+++ b/backend/spec/fixtures/files/not_an_image.txt
@@ -1,0 +1,1 @@
+this is not an image, just plain text bytes for the spoofed content-type spec.

--- a/backend/spec/requests/admin/image_bulk_imports_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_imports_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
     )
   end
 
+  # マジックバイト検査を通らない非画像ファイルを、宣言 content_type だけ image/jpeg と偽って送る
+  def upload_spoofed_non_image_blob
+    ActiveStorage::Blob.create_and_upload!(
+      io: Rails.root.join('spec/fixtures/files/not_an_image.txt').open,
+      filename: 'not_an_image.txt',
+      content_type: 'image/jpeg'
+    )
+  end
+
   describe 'GET /admin/image_bulk_import/new' do
     it 'renders the bulk import form' do
       get '/admin/image_bulk_import/new'
@@ -122,6 +131,46 @@ RSpec.describe 'Admin::ImageBulkImports', type: :request do
 
         perform_enqueued_jobs
         expect(ActiveStorage::Blob.exists?(second_blob.id)).to be(false)
+      end
+    end
+
+    describe 'サーバサイドのファイル検証' do
+      it 'rejects a non-image file whose content type is spoofed as image/jpeg, purging the blob' do
+        blob = upload_spoofed_non_image_blob
+
+        expect do
+          post '/admin/image_bulk_import', params: { bulk: { files: [blob.signed_id] } }
+        end.not_to change(Image, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include('画像ではありません')
+
+        perform_enqueued_jobs
+        expect(ActiveStorage::Blob.exists?(blob.id)).to be(false)
+      end
+
+      it 'rejects a file over the 50MB limit, purging the blob' do
+        blob = upload_fixture_blob
+        allow_any_instance_of(ActiveStorage::Blob)
+          .to receive(:byte_size).and_return(Admin::ImageBulkImportsController::MAX_FILE_SIZE + 1)
+
+        expect do
+          post '/admin/image_bulk_import', params: { bulk: { files: [blob.signed_id] } }
+        end.not_to change(Image, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include('サイズ上限50MBを超えています')
+
+        perform_enqueued_jobs
+        expect(ActiveStorage::Blob.exists?(blob.id)).to be(false)
+      end
+
+      it 'still ingests a valid image under the limit with the correct content type' do
+        expect do
+          post '/admin/image_bulk_import', params: { bulk: { files: [upload_fixture_blob.signed_id] } }
+        end.to change(Image, :count).by(1)
+
+        expect(response).to redirect_to(admin_images_path(filter: 'uncurated'))
       end
     end
 


### PR DESCRIPTION
## 概要
管理画面のバルク画像取込（direct upload）で、偽装された Content-Type によって非画像ファイルが下書き Image として登録されてしまう問題に対処する。ingest 時にサーバサイドでファイルを検証するようにした。

## 変更点
- `Admin::ImageBulkImportsController` に `MAX_FILE_SIZE`（50MB、Cloudflare Tunnel 無料プランの1リクエスト100MB上限に対する余裕を持たせた値）と `ACCEPTED_CONTENT_TYPES`（vips が扱えるラスター形式: jpeg/png/webp/heic/heif/tiff/gif/avif）を追加
- `ingest_draft` の Image 作成前に `blob_rejection_reason` でサイズ・形式を検証
  - サイズ超過はメタデータの `byte_size` のみで判定（S3 ダウンロード不要）
  - 形式判定は先頭4KBのみを ranged GET で取得し Marcel でマジックバイト判定。宣言 content_type と実バイト双方が許可リストに含まれる場合のみ受理し、偽装 Content-Type を弾く
  - 不正なファイルは既存のエラー経路と同様、per-file の結果表示・blob の `purge_later`・Image 未作成で処理
- `new.html.haml` に対応形式と50MB上限のフォーム案内文を追加（既存 CSS クラスのみ使用、inline style なし）
- リクエストスペックを追加: 偽装 Content-Type の非画像ファイル拒否、50MB超過ファイル拒否、正常な画像の取込を確認

## テスト
- `bundle exec rubocop` on 変更した `.rb` ファイル（controller / spec）: no offenses
- `bundle exec rspec spec/requests/admin/image_bulk_imports_spec.rb`: 11 examples, 0 failures
- `bundle exec rspec`（フルスイート）: 168 examples, 0 failures
- Playwright/e2e は対象外（ローカル実行は CI 専用構成のため未実施）

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)