### PR TITLE
feat(backend): variant と S3 実体の整合性チェック rake タスクを追加

### DIFF
--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -50,7 +50,13 @@ module CdnAttachedFile
 
     build_cdn_url(variant.key) || active_storage_url_for(variant)
   rescue StandardError, LoadError => e
-    Rails.logger.warn "variant_url fallback (#{log_reference}): #{e.class} #{e.message}"
+    # error 固定（warn からの意図的な格上げ）: 2026-06-18 の S3 アップロード失敗インシデントでは
+    # variant_generated? が DB のみを見るため silent fallback が唯一の手がかりだった。
+    # variant_key / blob_id を含めて grep・件数集計できるようにする（storage:verify_variants と対）。
+    Rails.logger.error(
+      "variant_url fallback (#{log_reference}): #{e.class} #{e.message} " \
+      "variant_key=#{variant&.key.inspect} blob_id=#{file.blob&.id.inspect}"
+    )
     file_url
   end
 

--- a/backend/lib/tasks/storage.rake
+++ b/backend/lib/tasks/storage.rake
@@ -1,0 +1,59 @@
+namespace :storage do
+  desc "Verify every ActiveStorage::VariantRecord's image actually exists in the storage " \
+       'service (S3). See #240: a failed upload can leave a VariantRecord/blob row without a ' \
+       "backing object, and variant_generated? (DB-only) can't detect that on its own. " \
+       'Pass FIX=1 to repair (re-generates via the standard processing path).'
+  task verify_variants: :environment do
+    verify_variants!(fix: ENV['FIX'] == '1')
+  end
+end
+
+def verify_variants!(fix:)
+  checked = 0
+  missing_ids = []
+
+  ActiveStorage::VariantRecord.includes(:blob, image_attachment: :blob).find_each do |variant_record|
+    checked += 1
+    next if variant_exists_on_storage?(variant_record)
+
+    missing_ids << variant_record.id
+    report_missing_variant(variant_record)
+    repair_variant_record!(variant_record) if fix
+  end
+
+  puts "storage:verify_variants: checked #{checked}, missing #{missing_ids.size}" \
+       "#{' (repaired)' if fix}."
+
+  return unless missing_ids.any? && !fix
+
+  abort "storage:verify_variants: #{missing_ids.size} variant(s) missing from S3 " \
+        "(ids=#{missing_ids.join(',')}). Re-run with FIX=1 to repair."
+end
+
+def variant_exists_on_storage?(variant_record)
+  image = variant_record.image
+  image.attached? && image.service.exist?(image.key)
+end
+
+def report_missing_variant(variant_record)
+  key = variant_record.image.attached? ? variant_record.image.key : '(no image attached)'
+  puts "  missing: variant_record=#{variant_record.id} key=#{key} " \
+       "owner_blob=#{variant_record.blob_id} owner_filename=#{variant_record.blob.filename}"
+end
+
+# variation_digest から元の resize パラメータ（resize_to_limit 等）を厳密に復元して
+# 直接 processed を呼び直すのは、Variation のシリアライズ形式に依存し壊れやすい。
+# よりシンプルで確実な方法を選ぶ: 孤児化した VariantRecord（と image の attachment）を
+# 破棄し、所有側レコード（Image/Project）の ProcessAttachedFileJob を再エンキューして、
+# 標準経路（CdnAttachedFile#ensure_variant_processed）にすべての variant を再生成させる。
+def repair_variant_record!(variant_record)
+  owners = variant_record.blob.attachments.filter_map(&:record).uniq
+
+  variant_record.image.purge if variant_record.image.attached?
+  variant_record.destroy!
+
+  owners.each do |owner|
+    puts "  -> re-enqueuing ProcessAttachedFileJob for #{owner.class.name}##{owner.id}"
+    ProcessAttachedFileJob.perform_later(owner)
+  end
+end

--- a/backend/spec/tasks/storage_verify_variants_spec.rb
+++ b/backend/spec/tasks/storage_verify_variants_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require 'rake'
+
+# 2026-06-18 インシデントの再現: S3 アップロード失敗で VariantRecord/blob 行は残るが
+# 実体（S3 オブジェクト）が無い状態を、test storage（Disk）上でファイルを直接消して模す。
+RSpec.describe 'storage:verify_variants rake task' do
+  include ActiveJob::TestHelper
+
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('storage:verify_variants')
+  end
+
+  let(:task) { Rake::Task['storage:verify_variants'] }
+
+  after { task.reenable }
+
+  around do |example|
+    original_fix = ENV.delete('FIX')
+    example.run
+    ENV['FIX'] = original_fix
+  end
+
+  def orphan_thumbnail_variant_record!(image)
+    perform_enqueued_jobs
+
+    # variant.variation.digest で実際に使われた digest を引く（resize_to_limit 以外にも
+    # processor 由来のデフォルトオプションが乗るため、手計算の digest とは一致しない）。
+    digest = image.thumbnail_variant.variation.digest
+    variant_record = ActiveStorage::VariantRecord.find_by!(blob_id: image.file.blob.id, variation_digest: digest)
+
+    blob = variant_record.image.blob
+    blob.service.delete(blob.key) # DB 上は generated 済みに見えるが実体が無い状態を再現する
+
+    variant_record
+  end
+
+  it 'detects a variant missing on S3 and fails loudly (non-zero exit) without FIX' do
+    image = create(:image)
+    variant_record = orphan_thumbnail_variant_record!(image)
+
+    expect { task.invoke }.to raise_error(SystemExit) { |error| expect(error.status).not_to eq(0) }
+    expect(ActiveStorage::VariantRecord.exists?(variant_record.id)).to be true
+  end
+
+  it 'repairs the missing variant when FIX=1' do
+    ENV['FIX'] = '1'
+    image = create(:image)
+    variant_record = orphan_thumbnail_variant_record!(image)
+
+    expect { task.invoke }.not_to raise_error
+    expect(ActiveStorage::VariantRecord.exists?(variant_record.id)).to be false
+
+    perform_enqueued_jobs
+    image.reload
+
+    expect(image.thumbnail_variant.image).to be_attached
+    expect(image.thumbnail_variant.service.exist?(image.thumbnail_variant.key)).to be true
+  end
+end


### PR DESCRIPTION
## 概要

#240 の最初の2項目を実装。2026-06-18 のインシデント（variant の S3 アップロード失敗により VariantRecord/blob は DB に残るが実体が無く、CloudFront 403 になった）を受けた対応。

## 変更点

- `backend/app/models/concerns/cdn_attached_file.rb`
  - `variant_url` の rescue フォールバック時のログを `Rails.logger.warn` から `Rails.logger.error` に格上げ。variant_key / blob_id をメッセージに含め、grep・件数集計しやすくした。フォールバック自体の挙動（file_url を返す）は変更していない（out of scope）。
- `backend/lib/tasks/storage.rake`（新規）
  - `storage:verify_variants` rake タスクを追加。全 `ActiveStorage::VariantRecord` をバッチ処理し、`image` の S3 実体が存在するか (`service.exist?(key)`) を検証。
  - 検出結果（checked 件数・missing 一覧: record id / key / owner blob filename）を puts で出力。
  - `FIX=1` で孤児化した VariantRecord（と image の attachment）を破棄し、所有レコード（Image/Project）の `ProcessAttachedFileJob` を再エンキューして標準経路で再生成する。variation_digest から resize パラメータを厳密復元して直接再生成する方式は Variation のシリアライズ形式に依存し壊れやすいため、シンプルで確実なこちらを選択（タスク内コメントに理由を明記）。
  - missing が見つかり `FIX` 未指定の場合は `abort` で non-zero exit（cron/CI 運用を想定した fail-loud）。
- `backend/spec/tasks/storage_verify_variants_spec.rb`（新規）
  - test storage（Disk）上で variant の実ファイルを直接削除してインシデント状態を再現し、(1) FIX 無しで検知・fail-loud、(2) `FIX=1` で VariantRecord 破棄 + ジョブ再エンキューによる再生成、を検証。

## テスト

Docker Compose（`docker compose run --rm backend ...`）で実行（ローカルの ruby 3.3.11 が未導入のため）。

- `bundle exec rubocop backend/app/models/concerns/cdn_attached_file.rb backend/lib/tasks/storage.rake backend/spec/tasks/storage_verify_variants_spec.rb` → no offenses detected
- `bundle exec rspec`（フルスイート, 167 examples）→ 0 failures
  - 新規 `spec/tasks/storage_verify_variants_spec.rb` を含め全件成功
  - なお `spec/requests/api/images_spec.rb` を単体実行すると id sequence 依存の既存フレーク（`id: 1` 固定 fixture と postgres sequence の衝突）が再現するが、フルスイート実行では発生せず、本変更とは無関係のプリエクジスティングな問題として確認済み

E2E（Playwright）は対象外。

Ref #240 （チェックボックスの最初の2項目が完了。issue 全体のクローズは対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)