### PR TITLE
fix(backend): ProcessAttachedFileJob の transient エラーを retry し失敗件数を admin に表示

### DIFF
--- a/backend/app/assets/stylesheets/admin.css
+++ b/backend/app/assets/stylesheets/admin.css
@@ -31,3 +31,8 @@
 .admin-progress-bar {
   width: 0;
 }
+
+/* ナビの「ジョブ」失敗件数バッジ（Solid Queue failed executions）。 */
+.admin-job-badge {
+  margin-left: 4px;
+}

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,8 +1,22 @@
 class ApplicationController < ActionController::Base
+  helper_method :failed_job_count
+
   private
 
   def file_dimensions(attachment)
     metadata = attachment.attached? ? attachment.metadata : {}
     [metadata['width']&.to_i, metadata['height']&.to_i]
+  end
+
+  # 管理画面ナビの「ジョブ」バッジ用件数。ログイン前ページ（layout 共有）でも
+  # 呼ばれるため admin 判定込みで 0 を返す。集計失敗時も画面を落とさず 0 fallback
+  # （fail-loud はジョブ本体側の責務なのでここでは rescue して log のみ）。
+  def failed_job_count
+    return 0 unless current_user&.role_admin?
+
+    SolidQueue::FailedExecution.count
+  rescue StandardError => e
+    Rails.logger.error("failed_job_count: #{e.class} #{e.message}")
+    0
   end
 end

--- a/backend/app/jobs/process_attached_file_job.rb
+++ b/backend/app/jobs/process_attached_file_job.rb
@@ -4,10 +4,23 @@
 class ProcessAttachedFileJob < ApplicationJob
   queue_as :default
 
+  # S3 / ネットワークの一過性エラー（可用性低下・スロットリング・タイムアウト）。
+  # vips のデコード失敗など恒久的なエラーはここに含めない（fail-loud のまま）。
+  TRANSIENT_ERRORS = [
+    Aws::S3::Errors::ServiceUnavailable,
+    Aws::S3::Errors::InternalError,
+    Aws::S3::Errors::SlowDown,
+    Seahorse::Client::NetworkingError,
+    Errno::ECONNRESET,
+    Net::OpenTimeout,
+    Net::ReadTimeout
+  ].freeze
+
   # io attach（rake/runner/フォーム）では after_commit のエンキューが S3 アップロード
   # 完了より先に走りうる（callback 定義順の race）。transient なので有限リトライし、
   # 使い切ったら fail-loud（failed executions に残る）。
   retry_on ActiveStorage::FileNotFoundError, wait: :polynomially_longer, attempts: 5
+  retry_on(*TRANSIENT_ERRORS, wait: :polynomially_longer, attempts: 5)
 
   def perform(record)
     record.process_attached_file!

--- a/backend/app/views/layouts/application.html.haml
+++ b/backend/app/views/layouts/application.html.haml
@@ -35,6 +35,11 @@
               %a.nav-link{:href => "/admin/categories"} カテゴリ
             %li.nav-item
               %a.nav-link{:href => "/admin/projects"} プロジェクト
+            - if failed_job_count.positive?
+              %li.nav-item
+                %a.nav-link{:href => "/admin/jobs"}
+                  ジョブ
+                  %span.badge.bg-danger.admin-job-badge= failed_job_count
     .container.mt-3
       - if flash.notice
         .alert.alert-info= flash.notice

--- a/backend/spec/jobs/process_attached_file_job_spec.rb
+++ b/backend/spec/jobs/process_attached_file_job_spec.rb
@@ -51,4 +51,39 @@ RSpec.describe ProcessAttachedFileJob, type: :job do
       expect { described_class.perform_now(image) }.to have_enqueued_job(described_class)
     end
   end
+
+  describe 'TRANSIENT_ERRORS retry configuration' do
+    it 'covers the expected S3 / network transient error classes' do
+      expect(described_class::TRANSIENT_ERRORS).to contain_exactly(
+        Aws::S3::Errors::ServiceUnavailable,
+        Aws::S3::Errors::InternalError,
+        Aws::S3::Errors::SlowDown,
+        Seahorse::Client::NetworkingError,
+        Errno::ECONNRESET,
+        Net::OpenTimeout,
+        Net::ReadTimeout
+      )
+    end
+
+    # TRANSIENT_ERRORS の一部（Errno::ECONNRESET）で実際に retry_on が起動することを
+    # 確認する代表ケース。上限到達後の再 raise は framework 保証なのでここでは検証しない。
+    it 'retries on a transient S3/network error (e.g. Errno::ECONNRESET)' do
+      image = create(:image)
+      allow(image).to receive(:process_attached_file!).and_raise(Errno::ECONNRESET)
+      clear_enqueued_jobs
+
+      expect { described_class.perform_now(image) }.to have_enqueued_job(described_class)
+    end
+
+    # 破損画像の vips デコード失敗など恒久的なエラーは retry_on の対象外のまま
+    # （fail-loud → failed executions に残る）ことを確認する。
+    it 'does not retry a non-transient StandardError and lets it propagate' do
+      image = create(:image)
+      allow(image).to receive(:process_attached_file!).and_raise(StandardError, 'corrupt image')
+      clear_enqueued_jobs
+
+      expect { described_class.perform_now(image) }.to raise_error(StandardError, 'corrupt image')
+      expect(enqueued_jobs).to be_empty
+    end
+  end
 end

--- a/backend/spec/requests/admin/job_badge_spec.rb
+++ b/backend/spec/requests/admin/job_badge_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin nav job badge', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user, :admin) }
+
+  before { sign_in user }
+
+  def create_failed_execution
+    job = SolidQueue::Job.create!(
+      queue_name: 'default', class_name: 'ProcessAttachedFileJob', arguments: '[]'
+    )
+    SolidQueue::FailedExecution.create!(
+      job: job, error: { exception_class: 'StandardError', message: 'boom', backtrace: [] }
+    )
+  end
+
+  describe 'GET /admin' do
+    it 'does not show the ジョブ badge when there are no failed executions' do
+      get admin_root_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include('admin-job-badge')
+    end
+
+    it 'shows the ジョブ badge with the failed execution count and links to /admin/jobs' do
+      create_failed_execution
+      create_failed_execution
+
+      get admin_root_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('/admin/jobs')
+      expect(response.body).to include('admin-job-badge')
+      expect(response.body).to include('>2<')
+    end
+
+    it 'falls back to hiding the badge and logs instead of raising a 500 when the count query fails' do
+      allow(SolidQueue::FailedExecution).to receive(:count).and_raise(ActiveRecord::StatementInvalid, 'boom')
+      allow(Rails.logger).to receive(:error)
+
+      get admin_root_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include('admin-job-badge')
+      expect(Rails.logger).to have_received(:error).with(/failed_job_count/)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
ProcessAttachedFileJob で S3 / ネットワークの一過性エラーをリトライ対象に追加し、Solid Queue の failed executions 件数を admin 画面のナビに表示して失敗を可視化する。

## 変更点
- `ProcessAttachedFileJob` に `TRANSIENT_ERRORS` 定数を追加し、`Aws::S3::Errors::ServiceUnavailable` / `InternalError` / `SlowDown`、`Seahorse::Client::NetworkingError`、`Errno::ECONNRESET`、`Net::OpenTimeout`、`Net::ReadTimeout` を `retry_on(wait: :polynomially_longer, attempts: 5)` でリトライ対象にした（既存の `ActiveStorage::FileNotFoundError` の retry_on はそのまま維持）。vips のデコード失敗などの恒久的な `StandardError` はリトライ対象外のままとし、fail-loud（failed executions に残る）を維持している。
- `ApplicationController#failed_job_count`（`helper_method`）を追加し、admin ログイン中のみ `SolidQueue::FailedExecution.count` を集計。集計に失敗しても画面を 500 にせず 0 にフォールバックしつつ `Rails.logger.error` で記録する。
- 管理画面ナビ（`app/views/layouts/application.html.haml`）に「ジョブ」リンク + バッジを追加し、失敗件数が 1 件以上のときだけ表示、`/admin/jobs`（Mission Control::Jobs）へ遷移できるようにした。
- バッジのスタイルは `admin.css` にクラスとして追加（本番 CSP が inline style をブロックするため、既存の運用に倣いクラス化）。

## テスト
- `bundle exec rspec spec/jobs/process_attached_file_job_spec.rb spec/requests/admin/job_badge_spec.rb spec/requests/admin/index_spec.rb spec/requests/admin/access_spec.rb` → 18 examples, 0 failures
- `bundle exec rspec`（フルスイート）→ 171 examples, 0 failures
- `bundle exec rubocop`（フルスキャン）→ 83 files inspected, no offenses detected
- Playwright/e2e は今回対象外（実施していません）

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)