### PR TITLE
管理画面 画像一覧の bulk 編集 UX 改善（キーボード操作・ページネーション・確認ダイアログ）

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -47,6 +47,9 @@ gem "haml-rails"
 
 gem "devise"
 
+# 管理画面 画像一覧のページネーション（全件ロード回避）
+gem "pagy", "~> 9.0"
+
 gem "image_processing", "~> 2.0"
 # image_processing 2.0 dropped its automatic ruby-vips dependency, so declare it explicitly
 gem "ruby-vips", "~> 2.2"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pagy (9.4.0)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -416,6 +417,7 @@ DEPENDENCIES
   image_processing (~> 2.0)
   importmap-rails
   mission_control-jobs
+  pagy (~> 9.0)
   pg (~> 1.5)
   puma (>= 6.4)
   rack-cors

--- a/backend/app/assets/stylesheets/admin.css
+++ b/backend/app/assets/stylesheets/admin.css
@@ -36,3 +36,9 @@
 .admin-job-badge {
   margin-left: 4px;
 }
+
+/* 画像一覧のキーボード操作でのアクティブ行。table-hover と衝突しない程度の強調。 */
+.bulk-edit-row-active {
+  background-color: rgba(13, 110, 253, 0.1);
+  box-shadow: inset 3px 0 0 #0d6efd;
+}

--- a/backend/app/controllers/admin/image_bulk_updates_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_updates_controller.rb
@@ -16,8 +16,8 @@ class Admin::ImageBulkUpdatesController < Admin::Base
 
   private
 
-  # 一括操作の戻り先。filter を引き継いで「絞ってから一括付与」のフローを維持する。
+  # 一括操作の戻り先。filter と page を引き継いで「絞ってから一括付与」のフローを維持する。
   def redirect_to_images(**flash_options)
-    redirect_to admin_images_path(filter: params[:filter].presence), **flash_options
+    redirect_to admin_images_path(filter: params[:filter].presence, page: params[:page].presence), **flash_options
   end
 end

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -1,14 +1,18 @@
 class Admin::ImagesController < Admin::Base
   include Admin::ImageCurationFlow
+  include Pagy::Backend
+
+  PER_PAGE = 50
 
   before_action :set_cameras_and_lenses_and_categories, only: %i[index new edit create update]
   before_action :set_image, only: %i[show edit update destroy insert_at]
   before_action :set_adjacent_images, only: %i[edit update]
 
   def index
-    @images = Image.order(:id).with_attached_file
+    scope = Image.order(:id).with_attached_file
+    scope = scope.uncurated if params[:filter] == "uncurated"
     @uncurated_count = Image.uncurated.count
-    @images = @images.uncurated if params[:filter] == "uncurated"
+    @pagy, @images = pagy(scope, limit: PER_PAGE)
   end
 
   # 並び替え専用画面。featured のみを表示する（ギャラリー先頭に pin される集合）。

--- a/backend/app/helpers/application_helper.rb
+++ b/backend/app/helpers/application_helper.rb
@@ -1,0 +1,3 @@
+module ApplicationHelper
+  include Pagy::Frontend
+end

--- a/backend/app/javascript/controllers/bulk_edit_controller.js
+++ b/backend/app/javascript/controllers/bulk_edit_controller.js
@@ -1,9 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
 
-// 画像一覧の一括編集。全選択トグル・選択数の表示・操作バーの表示/非表示だけを
-// 担当し、送信は素のフォーム POST（PATCH bulk_update）に任せる。
+// 画像一覧の一括編集。全選択トグル・選択数の表示・操作バーの表示/非表示・
+// キーボード操作（矢印で行移動、Space で選択、Enter で編集）を担当し、
+// 送信は素のフォーム POST（PATCH bulk_update）に任せる。
 export default class extends Controller {
-  static targets = ["checkbox", "selectAll", "bar", "count", "submit"]
+  static targets = ["checkbox", "selectAll", "bar", "count", "submit", "row"]
+
+  activeIndex = -1
 
   connect() {
     this.refresh()
@@ -24,5 +28,63 @@ export default class extends Controller {
     this.submitTarget.disabled = count === 0
     this.selectAllTarget.checked = count > 0 && count === this.checkboxTargets.length
     this.selectAllTarget.indeterminate = count > 0 && count < this.checkboxTargets.length
+  }
+
+  handleKeydown(event) {
+    const target = event.target
+    const isTextInput = /^(INPUT|SELECT|TEXTAREA)$/.test(target.tagName) && target.type !== "checkbox"
+    if (isTextInput || event.metaKey || event.ctrlKey || event.altKey) return
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        this.moveActive(1)
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        this.moveActive(-1)
+        break
+      case " ":
+        event.preventDefault()
+        this.toggleActive()
+        break
+      case "Enter":
+        this.visitActive()
+        break
+    }
+  }
+
+  moveActive(delta) {
+    if (this.rowTargets.length === 0) return
+
+    if (this.activeIndex === -1) {
+      this.activeIndex = delta > 0 ? 0 : this.rowTargets.length - 1
+    } else {
+      const next = this.activeIndex + delta
+      if (next < 0 || next >= this.rowTargets.length) return
+      this.activeIndex = next
+    }
+    this.setActiveRow()
+  }
+
+  setActiveRow() {
+    this.rowTargets.forEach((row) => row.classList.remove("bulk-edit-row-active"))
+    const row = this.rowTargets[this.activeIndex]
+    if (!row) return
+    row.classList.add("bulk-edit-row-active")
+    row.scrollIntoView({ block: "nearest" })
+  }
+
+  toggleActive() {
+    const row = this.rowTargets[this.activeIndex]
+    if (!row) return
+    const checkbox = this.checkboxTargets.find((cb) => row.contains(cb))
+    checkbox?.click()
+  }
+
+  visitActive() {
+    const row = this.rowTargets[this.activeIndex]
+    if (!row) return
+    Turbo.visit(row.dataset.editUrl)
   }
 }

--- a/backend/app/javascript/controllers/edit_nav_controller.js
+++ b/backend/app/javascript/controllers/edit_nav_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 編集フォームの ←/→ キーで前後の画像へ移動する。既存の nav_prev/nav_next submit
+// ボタンを踏むため、保存してから移動する挙動もボタンと同一になる。
+export default class extends Controller {
+  static targets = ["prev", "next"]
+
+  handleKeydown(event) {
+    const target = event.target
+    const isTextInput = /^(INPUT|SELECT|TEXTAREA)$/.test(target.tagName) && target.type !== "checkbox"
+    if (isTextInput || event.metaKey || event.ctrlKey || event.altKey) return
+
+    if (event.key === "ArrowLeft" && this.hasPrevTarget) {
+      event.preventDefault()
+      this.clickUnlessDisabled(this.prevTarget)
+    } else if (event.key === "ArrowRight" && this.hasNextTarget) {
+      event.preventDefault()
+      this.clickUnlessDisabled(this.nextTarget)
+    }
+  }
+
+  clickUnlessDisabled(button) {
+    if (button.disabled) return
+    button.click()
+  }
+}

--- a/backend/app/views/admin/images/_form.html.haml
+++ b/backend/app/views/admin/images/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: image, url: image.new_record? ? admin_images_path : admin_image_path(image), local: true, multipart: true, data: { controller: "exif-fill direct-upload" }) do |form|
+= form_with(model: image, url: image.new_record? ? admin_images_path : admin_image_path(image), local: true, multipart: true, data: { controller: "exif-fill direct-upload edit-nav", action: "keydown@document->edit-nav#handleKeydown" }) do |form|
   - if image.errors.any?
     .alert.alert-danger
       %ul.mb-0
@@ -60,7 +60,8 @@
         .card-footer.mt-auto
           .d-flex.justify-content-between.align-items-center.gap-2
             - if image.persisted?
-              = form.submit '← 前へ', name: 'nav_prev', class: 'btn btn-outline-secondary', disabled: local_assigns[:prev_image].nil?
+              = form.submit '← 前へ', name: 'nav_prev', class: 'btn btn-outline-secondary', disabled: local_assigns[:prev_image].nil?,
+                data: { edit_nav_target: "prev" }
             .d-flex.gap-2.mx-auto
               = form.submit '保存', class: 'btn btn-primary'
               - if image.is_published?
@@ -68,6 +69,7 @@
               - else
                 = form.submit '公開する', name: 'commit_publish', class: 'btn btn-success'
             - if image.persisted?
-              = form.submit '次へ →', name: 'nav_next', class: 'btn btn-outline-secondary', disabled: local_assigns[:next_image].nil?
+              = form.submit '次へ →', name: 'nav_next', class: 'btn btn-outline-secondary', disabled: local_assigns[:next_image].nil?,
+                data: { edit_nav_target: "next" }
           - unless image.is_published?
             %small.text-muted.d-block.text-center.mt-1 公開にはタイトルと撮影日時が必要です

--- a/backend/app/views/admin/images/_image_row.html.haml
+++ b/backend/app/views/admin/images/_image_row.html.haml
@@ -1,4 +1,5 @@
-%tr.cursor-pointer{"data-image-id": image.id}
+%tr.cursor-pointer{"data-image-id": image.id,
+  data: { bulk_edit_target: "row", edit_url: edit_admin_image_path(image) } }
   %td
     = check_box_tag 'image_ids[]', image.id, false,
       id: "select_image_#{image.id}", class: 'form-check-input', "aria-label": "選択",

--- a/backend/app/views/admin/images/index.html.haml
+++ b/backend/app/views/admin/images/index.html.haml
@@ -17,6 +17,7 @@
 = form_with(url: admin_image_bulk_update_path, method: :patch, local: true,
   data: { controller: "bulk-edit", action: "keydown@document->bulk-edit#handleKeydown" }) do
   = hidden_field_tag :filter, params[:filter]
+  = hidden_field_tag :page, params[:page]
   .table-responsive
     %table.table.table-hover.align-middle
       %thead
@@ -30,6 +31,10 @@
       %tbody
         - @images.each do |image|
           = render 'image_row', image: image
+
+  - if @pagy.pages > 1
+    %nav.d-flex.justify-content-center{"aria-label": "ページ切り替え"}
+      != pagy_bootstrap_nav(@pagy)
 
   -# 選択中のみ表示される一括操作バー。空欄の項目は変更されない（クリアは単体編集で）。
   .card.position-sticky.bottom-0.mb-3.shadow.d-none{ data: { bulk_edit_target: "bar" } }
@@ -55,4 +60,4 @@
                   id: "bulk_category_#{category.id}", class: 'form-check-input'
                 = label_tag "bulk_category_#{category.id}", category.name, class: 'form-check-label'
         = submit_tag '選択した画像に適用', class: 'btn btn-primary btn-sm ms-auto',
-          data: { bulk_edit_target: "submit" }
+          data: { bulk_edit_target: "submit", turbo_confirm: '選択した画像に一括適用します。よろしいですか？' }

--- a/backend/app/views/admin/images/index.html.haml
+++ b/backend/app/views/admin/images/index.html.haml
@@ -14,7 +14,8 @@
       = "未編集の下書き #{@uncurated_count} 枚を表示。"
       = link_to '未編集のみ表示', admin_images_path(filter: "uncurated")
 
-= form_with(url: admin_image_bulk_update_path, method: :patch, local: true, data: { controller: "bulk-edit" }) do
+= form_with(url: admin_image_bulk_update_path, method: :patch, local: true,
+  data: { controller: "bulk-edit", action: "keydown@document->bulk-edit#handleKeydown" }) do
   = hidden_field_tag :filter, params[:filter]
   .table-responsive
     %table.table.table-hover.align-middle

--- a/backend/config/initializers/pagy.rb
+++ b/backend/config/initializers/pagy.rb
@@ -1,0 +1,6 @@
+require "pagy/extras/bootstrap"
+require "pagy/extras/overflow"
+
+# ページ数を超えた page param（一括操作でページ数が減った直後など）は最終ページに丸める
+Pagy::DEFAULT[:overflow] = :last_page
+Pagy::DEFAULT.freeze

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -41,6 +41,26 @@ RSpec.describe 'Admin::Images', type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("data-image-id='#{draft.id}'").or include("data-image-id=\"#{draft.id}\"")
     end
+
+    it 'paginates the list and preserves the filter in page links' do
+      stub_const('Admin::ImagesController::PER_PAGE', 2)
+
+      get '/admin/images', params: { page: 2 }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("select_image_#{image3.id}")
+      expect(response.body).not_to include("select_image_#{image1.id}")
+      expect(response.body).to include('pagination')
+    end
+
+    it 'rounds an out-of-range page down to the last page instead of erroring' do
+      stub_const('Admin::ImagesController::PER_PAGE', 2)
+
+      get '/admin/images', params: { page: 99 }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("select_image_#{image4.id}")
+    end
   end
 
   describe 'GET /admin/images/arrange' do


### PR DESCRIPTION
## 概要
画像大量投入を前に、管理画面の画像一覧（bulk 編集）へキーボード操作・ページネーション・一括適用の確認ダイアログを追加する。

## レビュー優先度
🔴 全文レビュー — 新規 JS ロジック + 新規依存（pagy）+ 一覧クエリの挙動変更のため

## 判断・トレードオフ
- ページネーションは kaminari ではなく **pagy (~> 9.0)** を採用（軽量・依存少）。50件/ページは仮置きで、`Admin::ImagesController::PER_PAGE` の1定数で変更可
- 範囲外 page は overflow extra で**最終ページに丸める**（一括操作でページ数が減った直後のエラーを回避）
- キー割り当ては ↑↓=行移動 / Space=選択トグル / **Enter=編集ページへ遷移**。Enter は要らなければ外せる
- アクティブ行のハイライトは prod CSP（inline style 無効）対応のため CSS クラス方式
- 確認ダイアログは静的文言（選択枚数の動的埋め込みは JS が要るので見送り）

## 確認
- rspec フルスイート 178 examples, 0 failures / rubocop 87 files, no offenses
- ページネーション（page 2 の表示内容・範囲外 page の丸め）は request spec で担保
- **実描画は未確認**（手元ルール通りユーザーが確認予定: ↑↓/Space/Enter の挙動、ハイライトと table-hover の重なり、ページネーション UI、確認ダイアログ）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)