### PR TITLE
fix: コード品質修正 3件（insert_at 境界・sortable エラー表示・tags 重複除去）

### DIFF
--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -70,7 +70,7 @@ class Admin::ImagesController < Admin::Base
   # 全体を 0..N-1 へ正規化する。
   def insert_at
     ids = Image.featured.where.not(id: @image.id).pluck(:id)
-    ids.insert(insert_params.to_i, @image.id)
+    ids.insert(insert_params.to_i.clamp(0, ids.size), @image.id)
     Image.reorder_featured!(ids)
     head :ok
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e

--- a/backend/app/javascript/controllers/sortable_controller.js
+++ b/backend/app/javascript/controllers/sortable_controller.js
@@ -50,8 +50,9 @@ export default class extends Controller {
   }
 
   #showError() {
+    document.querySelectorAll('.sortable-error-flash').forEach((el) => el.remove())
     const flashDiv = document.createElement('div')
-    flashDiv.className = 'alert alert-danger'
+    flashDiv.className = 'alert alert-danger sortable-error-flash'
     flashDiv.textContent = '並び替えに失敗しました'
     const container = document.querySelector('.container')
     if (container) {

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -11,7 +11,7 @@ class Project < ApplicationRecord
 
   # Admin form submits tags as a comma-separated string.
   def tags=(value)
-    value = value.split(",").map(&:strip).reject(&:empty?) if value.is_a?(String)
+    value = value.split(",").map(&:strip).reject(&:empty?).uniq if value.is_a?(String)
     super(value || [])
   end
 end


### PR DESCRIPTION
## 概要

定期コード品質チェックで発見した 3 件のバグ修正です。

## 変更内容

### 1. `insert_at` — position の境界チェック追加
`params[:position]` の値が featured リストの範囲外の場合、Ruby の `Array#insert` が `nil` エントリを挿入し、`reorder_featured!` が `RecordNotFound` で失敗していました。`.clamp(0, ids.size)` で常に有効な範囲に丸めます。

### 2. `sortable_controller.js` — エラーフラッシュの重複挿入を修正
並び替え失敗時のエラーメッセージが `div` として挿入されるが削除されないため、複数回失敗するとエラー表示が積み重なる UX バグを修正しました。新規挿入の前に既存のフラッシュ div を削除します。

### 3. `Project#tags=` — タグ重複除去を追加
「Ruby, Ruby, Rails」のような入力で重複タグが保存されていました。`.uniq` で重複を除去します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xucekpyot71Ui9HktMD4qt)_