### PR TITLE
feat(backend): 画像一覧の一括適用に撮影日時(taken_at)の一括付与を追加

### DIFF
--- a/backend/app/controllers/admin/image_bulk_updates_controller.rb
+++ b/backend/app/controllers/admin/image_bulk_updates_controller.rb
@@ -8,13 +8,23 @@ class Admin::ImageBulkUpdatesController < Admin::Base
     camera = Camera.find(params[:camera_id]) if params[:camera_id].present?
     lens = Lens.find(params[:lens_id]) if params[:lens_id].present?
     categories = Category.where(id: Array(params[:category_ids]).compact_blank).to_a
-    return redirect_to_images(alert: '適用する項目が選択されていません。') if camera.nil? && lens.nil? && categories.empty?
+    taken_at_base = parse_taken_at_base
+    return redirect_to_images(alert: '適用する項目が選択されていません。') if nothing_to_apply?(camera, lens, categories, taken_at_base)
 
-    images = Image.bulk_assign!(image_ids, camera: camera, lens: lens, categories: categories)
+    images = Image.bulk_assign!(image_ids, camera: camera, lens: lens, categories: categories,
+                                           taken_at_base: taken_at_base)
     redirect_to_images(notice: "#{images.size}枚に一括適用しました。")
   end
 
   private
+
+  def parse_taken_at_base
+    Time.zone.parse(params[:taken_at]) if params[:taken_at].presence
+  end
+
+  def nothing_to_apply?(camera, lens, categories, taken_at_base)
+    camera.nil? && lens.nil? && categories.empty? && taken_at_base.nil?
+  end
 
   # 一括操作の戻り先。filter と page を引き継いで「絞ってから一括付与」のフローを維持する。
   def redirect_to_images(**flash_options)

--- a/backend/app/models/image.rb
+++ b/backend/app/models/image.rb
@@ -50,13 +50,17 @@ class Image < ApplicationRecord
 
   # 一括メタデータ付与。nil の属性は変更せず、カテゴリは既存への追加（union）。
   # 部分成功を作らない：ID の欠落や 1 件の失敗で全体をロールバックする（fail-loud）。
-  def self.bulk_assign!(ids, camera: nil, lens: nil, categories: [])
+  # taken_at_base 指定時は id 昇順（≒取り込み順≒コマ順）で 1 分ずつオフセットして付与する。
+  # 公開ページの表示順が taken_at DESC のため、同一時刻を複数枚に入れるとロール内の並びが不定になる。
+  def self.bulk_assign!(ids, camera: nil, lens: nil, categories: [], taken_at_base: nil)
     images = where(id: ids).to_a
     raise ActiveRecord::RecordNotFound, 'Some images not found' if images.size != ids.uniq.size
 
     transaction do
-      images.each do |image|
-        image.update!({ camera: camera, lens: lens }.compact)
+      images.sort_by(&:id).each_with_index do |image, index|
+        attrs = { camera: camera, lens: lens }.compact
+        attrs[:taken_at] = taken_at_base + index.minutes if taken_at_base
+        image.update!(attrs)
         categories.each { |category| image.image_categories.find_or_create_by!(category: category) }
       end
     end

--- a/backend/app/views/admin/images/index.html.haml
+++ b/backend/app/views/admin/images/index.html.haml
@@ -51,6 +51,9 @@
           = label_tag :lens_id, 'レンズ', class: 'col-form-label col-form-label-sm text-nowrap'
           = select_tag :lens_id, options_from_collection_for_select(@lenses, :id, :name),
             include_blank: '変更しない', class: 'form-select form-select-sm'
+        .d-flex.align-items-center.gap-1
+          = label_tag :taken_at, '撮影日時', class: 'col-form-label col-form-label-sm text-nowrap'
+          = datetime_field_tag :taken_at, nil, class: 'form-control form-control-sm'
         - if @categories.any?
           .d-flex.align-items-center.gap-2
             %span.col-form-label.col-form-label-sm.text-nowrap カテゴリ追加

--- a/backend/spec/models/image_spec.rb
+++ b/backend/spec/models/image_spec.rb
@@ -378,4 +378,38 @@ RSpec.describe Image, type: :model do
       end
     end
   end
+
+  describe '.bulk_assign!' do
+    it 'offsets taken_at by 1 minute per image in id order when taken_at_base is given' do
+      a = create(:image)
+      b = create(:image)
+      c = create(:image)
+      base = Time.zone.parse('2024-01-01 10:00:00')
+
+      Image.bulk_assign!([a.id, b.id, c.id], taken_at_base: base)
+
+      ordered = [a, b, c].sort_by(&:id)
+      ordered.each_with_index do |image, index|
+        expect(image.reload.taken_at).to eq(base + index.minutes)
+      end
+    end
+
+    it 'does not change taken_at when taken_at_base is nil' do
+      image = create(:image, taken_at: 1.day.ago.change(usec: 0))
+      original_taken_at = image.taken_at
+
+      Image.bulk_assign!([image.id])
+
+      expect(image.reload.taken_at).to eq(original_taken_at)
+    end
+
+    it 'overwrites an existing taken_at when taken_at_base is given' do
+      image = create(:image, taken_at: 10.days.ago.change(usec: 0))
+      base = Time.zone.parse('2024-01-01 10:00:00')
+
+      Image.bulk_assign!([image.id], taken_at_base: base)
+
+      expect(image.reload.taken_at).to eq(base)
+    end
+  end
 end

--- a/backend/spec/requests/admin/image_bulk_updates_spec.rb
+++ b/backend/spec/requests/admin/image_bulk_updates_spec.rb
@@ -82,5 +82,27 @@ RSpec.describe 'Admin::ImageBulkUpdates', type: :request do
 
       expect(response).to have_http_status(:not_found)
     end
+
+    it 'assigns taken_at with a 1-minute offset per image in id order, with no camera/lens selected' do
+      patch '/admin/image_bulk_update',
+            params: { image_ids: [image1.id, image2.id], taken_at: '2024-01-01T10:00' }
+
+      expect(response).to redirect_to(admin_images_path)
+      expect(flash[:notice]).to include('2枚')
+
+      ordered = [image1, image2].sort_by(&:id)
+      base = Time.zone.parse('2024-01-01T10:00')
+      ordered.each_with_index do |image, index|
+        expect(image.reload.taken_at).to eq(base + index.minutes)
+      end
+    end
+
+    it 'leaves taken_at untouched when the field is blank' do
+      original_taken_at = image1.taken_at
+
+      patch '/admin/image_bulk_update', params: { image_ids: [image1.id], camera_id: camera.id, taken_at: '' }
+
+      expect(image1.reload.taken_at).to eq(original_taken_at)
+    end
   end
 end


### PR DESCRIPTION
## 概要
フィルム写真など EXIF のない画像向けに、画像一覧の一括適用バーから taken_at をまとめて設定できるようにする。

## レビュー優先度
🔴 全文レビュー — `bulk_assign!` のロジック変更を含む新機能

## 判断・トレードオフ
- 公開ページの表示順が taken_at DESC のため、同一時刻を複数枚に入れるとロール内の並びが不定になる。id 昇順（≒取り込み順≒コマ順）に基準日時から **1 分ずつオフセット**して付与する
- taken_at は指定時に**既存値も上書き**（camera/lens と同じ「指定したら適用」、空欄は変更しない）
- bulk import 側でなく一覧の一括適用バーに載せた。取り込みバッチとロール（撮影単位）が一致しない運用のため、サムネイルを見ながら選択→適用できる一覧側が適切

## 確認
rspec（model + request、56 examples / 0 failures）と rubocop（0 offenses）のみ。管理画面の実描画・実操作は未確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)