### PR TITLE
perf: 画像取込の添付後処理を軽量化（S3 GET 5回→1回・bulk_assign! の N+1 解消）

### DIFF
--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -14,9 +14,11 @@ module CdnAttachedFile
   def process_attached_file!
     return unless file.attached?
 
-    file.analyze unless file.analyzed?
-    variant_limits.each { |limit| ensure_variant_processed(variant_for(limit)) }
-    after_attached_file_processed
+    with_single_blob_download(file.blob) do
+      file.analyze unless file.analyzed?
+      variant_limits.each { |limit| ensure_variant_processed(variant_for(limit)) }
+      after_attached_file_processed
+    end
   end
 
   # variant 生成後・同一ジョブ内で呼ばれるモデル固有の後処理フック（デフォルト no-op）。
@@ -37,9 +39,7 @@ module CdnAttachedFile
   end
 
   def variant_for(limit)
-    return unless file.attached?
-
-    file.variant(resize_to_limit: limit)
+    file.variant(resize_to_limit: limit) if file.attached?
   end
 
   def variant_url(limit)
@@ -71,8 +71,7 @@ module CdnAttachedFile
     # variant-record lookup 自体を走らせない。attachment_changes はこの after_commit の
     # 時点ではまだ残っている（ActiveStorage 側の upload/clear は has_one_attached の
     # 定義位置の都合で後に実行される）。
-    return unless attachment_changes.key?("file")
-    return unless attached_file_needs_processing?
+    return unless attachment_changes.key?("file") && attached_file_needs_processing?
 
     ProcessAttachedFileJob.perform_later(self)
   end
@@ -82,8 +81,24 @@ module CdnAttachedFile
   def attached_file_needs_processing?
     return false unless file.attached?
 
-    !file.analyzed? ||
-      variant_limits.any? { |limit| !variant_generated?(variant_for(limit)) }
+    !file.analyzed? || variant_limits.any? { |limit| !variant_generated?(variant_for(limit)) }
+  end
+
+  # analyze・variant 生成・EXIF 抽出（ExifExtractor.from_blob）はいずれも blob.open で
+  # 各自ダウンロードするため、1ジョブで同一 blob を S3 から約4回取得していた（#276）。
+  # ここで1回だけダウンロードし（checksum 検証込み）、この blob インスタンスに限り
+  # open をキャッシュ済み tempfile の払い出しに差し替えて共有する。処理は同一ジョブ内で
+  # 逐次実行なので tempfile の共有は rewind だけで安全。
+  def with_single_blob_download(blob)
+    blob.open do |tempfile|
+      blob.define_singleton_method(:open) do |**, &reader|
+        reader.call(tempfile.tap(&:rewind))
+      end
+      yield
+    ensure
+      # tempfile は外側の open 終了で unlink されるため、差し替えたままにしない
+      blob.singleton_class.remove_method(:open)
+    end
   end
 
   def log_reference = "#{self.class.name.underscore} #{id}"

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -67,13 +67,18 @@ module CdnAttachedFile
   def variant_limits = [thumbnail_limit, display_limit]
 
   def enqueue_attached_file_processing
+    # 添付が変わっていない save（タイトル編集・bulk_assign!・ジョブ内の EXIF save! 等）では
+    # variant-record lookup 自体を走らせない。attachment_changes はこの after_commit の
+    # 時点ではまだ残っている（ActiveStorage 側の upload/clear は has_one_attached の
+    # 定義位置の都合で後に実行される）。
+    return unless attachment_changes.key?("file")
     return unless attached_file_needs_processing?
 
     ProcessAttachedFileJob.perform_later(self)
   end
 
-  # 導出で判定する（処理状態カラムは持たない）。analyze 済み・variant 生成済みなら
-  # 保存しても再エンキューされず、ジョブ内の save で連鎖が止まる。
+  # 導出で判定する（処理状態カラムは持たない）。添付が変わった保存だけがここに来るので、
+  # 既存 blob の再添付（signed_id 経由の重複添付など）で処理済みなら再エンキューしない。
   def attached_file_needs_processing?
     return false unless file.attached?
 

--- a/backend/app/services/exif_extractor.rb
+++ b/backend/app/services/exif_extractor.rb
@@ -13,8 +13,10 @@ class ExifExtractor
     offset_time_original: "exif-ifd2-OffsetTimeOriginal"
   }.freeze
 
+  # blob.download ではなく blob.open を使う: ProcessAttachedFileJob 内では
+  # ダウンロード済み tempfile が共有され、S3 GET が増えない（CdnAttachedFile#276）。
   def self.from_blob(blob)
-    new(blob.download).call
+    blob.open { |file| new(file.read).call }
   rescue StandardError => e
     Rails.logger.warn "ExifExtractor.from_blob failed: #{e.class} #{e.message}"
     EMPTY

--- a/backend/config/initializers/skip_builtin_analyze_job.rb
+++ b/backend/config/initializers/skip_builtin_analyze_job.rb
@@ -1,0 +1,21 @@
+# CdnAttachedFile を include するモデル（Image / Project）の添付は
+# ProcessAttachedFileJob が analyze まで担うため、attach 時に ActiveStorage が
+# 自動 enqueue する AnalyzeJob（無条件 blob.analyze → S3 GET + フルデコード）は
+# まるごと二重処理になる。該当モデルの添付に限り enqueue 自体を抑止する（#276）。
+#
+# NOTE: private メソッド analyze_blob_later（after_create_commit フック）の上書き。
+# Rails 更新でフック名が変われば prepend が空振りして標準動作（余分な解析）に
+# 戻るだけで、機能は壊れない。
+module SkipBuiltinAnalyzeJobForCdnAttachedFile
+  private
+
+  def analyze_blob_later
+    return if record.is_a?(CdnAttachedFile)
+
+    super
+  end
+end
+
+ActiveSupport.on_load(:active_storage_attachment) do
+  prepend SkipBuiltinAnalyzeJobForCdnAttachedFile
+end

--- a/backend/spec/jobs/process_attached_file_job_spec.rb
+++ b/backend/spec/jobs/process_attached_file_job_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe ProcessAttachedFileJob, type: :job do
       expect(queries).to be_empty
     end
 
+    # 本ジョブが analyze まで担うため、ActiveStorage 標準の AnalyzeJob は
+    # 二重処理としてまるごと抑止している（initializer 参照。#276）。
+    it 'does not enqueue the builtin ActiveStorage::AnalyzeJob' do
+      expect { create(:image) }.not_to have_enqueued_job(ActiveStorage::AnalyzeJob)
+    end
+
     it 'enqueues again when the file itself is replaced' do
       image = create(:image)
       perform_enqueued_jobs
@@ -63,14 +69,15 @@ RSpec.describe ProcessAttachedFileJob, type: :job do
       expect(image.taken_at).to be_present
     end
 
-    # analyze・variant×2・EXIF で計4回ダウンロードしていた経路の回帰テスト（#276）。
-    # storage service への download 呼び出し回数で S3 GET を計測する。
-    it 'downloads the original blob from storage only once per job (regression: #276)' do
+    # analyze・variant×2・EXIF の計4回 + 標準 AnalyzeJob の1回をダウンロードしていた
+    # 経路の回帰テスト（#276）。storage service への download 呼び出し回数で
+    # S3 GET を計測する（enqueue された全ジョブを流して取込1件分の合計を見る）。
+    it 'downloads the original blob from storage only once per ingest (regression: #276)' do
       image = create(:image, :draft)
       service = ActiveStorage::Blob.service
       allow(service).to receive(:download).and_call_original
 
-      perform_enqueued_jobs(only: described_class)
+      perform_enqueued_jobs
 
       image.reload
       expect(service).to have_received(:download).with(image.file.blob.key).once

--- a/backend/spec/jobs/process_attached_file_job_spec.rb
+++ b/backend/spec/jobs/process_attached_file_job_spec.rb
@@ -63,6 +63,23 @@ RSpec.describe ProcessAttachedFileJob, type: :job do
       expect(image.taken_at).to be_present
     end
 
+    # analyze・variant×2・EXIF で計4回ダウンロードしていた経路の回帰テスト（#276）。
+    # storage service への download 呼び出し回数で S3 GET を計測する。
+    it 'downloads the original blob from storage only once per job (regression: #276)' do
+      image = create(:image, :draft)
+      service = ActiveStorage::Blob.service
+      allow(service).to receive(:download).and_call_original
+
+      perform_enqueued_jobs(only: described_class)
+
+      image.reload
+      expect(service).to have_received(:download).with(image.file.blob.key).once
+      # ダウンロード共有後も全工程が成立していること（analyze / variant / EXIF）
+      expect(image.file).to be_analyzed
+      expect(image.thumbnail_variant.image).to be_attached
+      expect(image.camera).to be_present
+    end
+
     it 'processes records without EXIF support (Project)' do
       project = build(:project)
       project.file = Rack::Test::UploadedFile.new(

--- a/backend/spec/jobs/process_attached_file_job_spec.rb
+++ b/backend/spec/jobs/process_attached_file_job_spec.rb
@@ -14,6 +14,40 @@ RSpec.describe ProcessAttachedFileJob, type: :job do
 
       expect { image.reload.update!(title: 'renamed') }.not_to have_enqueued_job(described_class)
     end
+
+    # 処理待ちのままでも、添付が変わらない update（キュレーション編集）で
+    # 重複ジョブを積まない（#277）。
+    it 'does not enqueue a duplicate job on a file-unchanged update while still unprocessed' do
+      image = create(:image)
+      clear_enqueued_jobs
+
+      expect { image.reload.update!(title: 'renamed') }.not_to have_enqueued_job(described_class)
+    end
+
+    it 'does not look up variant records on a file-unchanged update (regression: #277)' do
+      image = create(:image)
+      perform_enqueued_jobs
+      reloaded = Image.find(image.id)
+
+      queries = sql_queries_matching(/active_storage_variant_records/) do
+        reloaded.update!(title: 'renamed')
+      end
+
+      expect(queries).to be_empty
+    end
+
+    it 'enqueues again when the file itself is replaced' do
+      image = create(:image)
+      perform_enqueued_jobs
+      clear_enqueued_jobs
+
+      expect do
+        image.reload.file.attach(
+          io: Rails.root.join('spec/fixtures/files/test_image.jpg').open,
+          filename: 'replaced.jpg', content_type: 'image/jpeg'
+        )
+      end.to have_enqueued_job(described_class)
+    end
   end
 
   describe '#perform' do

--- a/backend/spec/models/image_spec.rb
+++ b/backend/spec/models/image_spec.rb
@@ -380,6 +380,8 @@ RSpec.describe Image, type: :model do
   end
 
   describe '.bulk_assign!' do
+    include ActiveJob::TestHelper
+
     it 'offsets taken_at by 1 minute per image in id order when taken_at_base is given' do
       a = create(:image)
       b = create(:image)
@@ -410,6 +412,21 @@ RSpec.describe Image, type: :model do
       Image.bulk_assign!([image.id], taken_at_base: base)
 
       expect(image.reload.taken_at).to eq(base)
+    end
+
+    # 添付は変わらないので、画像数に比例した variant-record lookup（N+1）を発行しない
+    # （クエリ数ゼロで固定する回帰テスト。#277）。処理済み（analyzed）でないと
+    # 旧実装でも analyzed? で短絡して再現しないため、先にジョブを流す。
+    it 'does not run per-image variant-record lookups (regression: #277)' do
+      images = create_list(:image, 3)
+      perform_enqueued_jobs
+      base = Time.zone.parse('2024-01-01 10:00:00')
+
+      queries = sql_queries_matching(/active_storage_variant_records/) do
+        Image.bulk_assign!(images.map(&:id), taken_at_base: base)
+      end
+
+      expect(queries).to be_empty
     end
   end
 end

--- a/backend/spec/support/query_counting.rb
+++ b/backend/spec/support/query_counting.rb
@@ -1,0 +1,13 @@
+# 特定テーブルへの SQL 発行を回帰テストで固定するためのヘルパー（N+1 の再発防止用）。
+module QueryCounting
+  def sql_queries_matching(pattern, &)
+    queries = []
+    callback = lambda do |_name, _start, _finish, _id, payload|
+      queries << payload[:sql] if payload[:sql].match?(pattern)
+    end
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &)
+    queries
+  end
+end
+
+RSpec.configure { |config| config.include QueryCounting }


### PR DESCRIPTION
## 概要
画像大量投入に備え、添付後処理の重複ダウンロード（#276）と添付無変更 update の variant-record lookup N+1（#277）を解消する。

Closes #276
Closes #277

## レビュー優先度
🔴 全文レビュー — 添付処理パイプラインのロジック変更 + ActiveStorage 内部フックへの介入を含むため

## 判断・トレードオフ
- **ダウンロード共有は blob インスタンス限定の `open` 差し替えで実現**: analyze・variant 生成・EXIF は全て `blob.open` を通るため、variant パイプライン（`VariantWithRecord#process` の create_or_find_by! 等）を自前で再実装するより、Rails 内部ロジックを無傷で通すこの方式を選んだ。差し替えは1ジョブ内で完結し ensure で除去する。
- **標準 AnalyzeJob の抑止（3コミット目）**: issue に書かれていない5回目の GET として、attach 時に自動 enqueue される `ActiveStorage::AnalyzeJob`（無条件 `blob.analyze`）を発見。本アプリでは ProcessAttachedFileJob が analyze を担うため完全な二重処理であり、`analyze_blob_later`（private フック）を prepend で CdnAttachedFile モデルに限り抑止した。Rails 更新でフック名が変われば標準動作（余分な解析）に戻るだけで機能は壊れない。
- **#277 のガードで「保存し直して再処理」の暗黙経路は消える**: 失敗ジョブは Solid Queue の failed executions からリトライ、整合性は `storage:verify_variants` で検知する運用とした（issue の「発火条件だけ絞る」想定どおり）。
- `variant_for` の圧縮は Metrics/ModuleLength 対応の等価変形。

## 確認
- 全 spec 189 例グリーン・RuboCop クリーン
- 回帰テスト3件（重複 enqueue / variant lookup ゼロ / bulk_assign! N+1）が修正前コードで 3/3 失敗することを stash で確認
- S3 GET は storage service への download 呼び出し回数で計測し、取込1件（analyze + variant×2 + EXIF + 標準 AnalyzeJob 分）で計1回になることを spec で固定

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)