### PR TITLE
fix: コード品質チェック 2026-07-31 の軽微な修正

### DIFF
--- a/backend/app/views/layouts/application.html.haml
+++ b/backend/app/views/layouts/application.html.haml
@@ -4,7 +4,6 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %meta{:charset => "utf-8"}/
     %meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}/
-    %meta{:content => "width=device-width,initial-scale=1", :name => "viewport"}/
     = csrf_meta_tags
     = csp_meta_tag
     = javascript_importmap_tags
@@ -22,19 +21,19 @@
   %body
     %nav.navbar.navbar-expand-lg.navbar-light.bg-light
       .container
-        %a.navbar-brand{:href => "/admin"} ダッシュボード
+        = link_to 'ダッシュボード', admin_root_path, class: 'navbar-brand'
         %button.navbar-toggler{"aria-controls" => "navbarNav", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-bs-target" => "#navbarNav", "data-bs-toggle" => "collapse", :type => "button"}
           %span.navbar-toggler-icon
         #navbarNav.collapse.navbar-collapse
           %ul.navbar-nav
             %li.nav-item
-              %a.nav-link{:href => "/admin/images"} 画像
+              = link_to '画像', admin_images_path, class: 'nav-link'
             %li.nav-item
-              %a.nav-link{:href => "/admin/gear"} 機材
+              = link_to '機材', admin_gear_path, class: 'nav-link'
             %li.nav-item
-              %a.nav-link{:href => "/admin/categories"} カテゴリ
+              = link_to 'カテゴリ', admin_categories_path, class: 'nav-link'
             %li.nav-item
-              %a.nav-link{:href => "/admin/projects"} プロジェクト
+              = link_to 'プロジェクト', admin_projects_path, class: 'nav-link'
             - if failed_job_count.positive?
               %li.nav-item
                 %a.nav-link{:href => "/admin/jobs"}

--- a/frontend/src/app/_components/GallerySection.tsx
+++ b/frontend/src/app/_components/GallerySection.tsx
@@ -14,7 +14,7 @@ export default async function GallerySection() {
           </h2>
           <Link
             href="/gallery"
-            className="inline-flex items-center gap-2 text-sm font-medium text-foreground transition hover:text-blue-600"
+            className="inline-flex items-center gap-2 text-sm font-medium text-foreground transition hover:text-accent"
           >
             Show More
             <span aria-hidden>→</span>

--- a/frontend/src/app/_components/ProjectsSection.tsx
+++ b/frontend/src/app/_components/ProjectsSection.tsx
@@ -13,7 +13,7 @@ export default async function ProjectsSection() {
           </h2>
           <Link
             href="/projects"
-            className="inline-flex items-center gap-2 text-sm font-medium text-foreground transition hover:text-blue-600"
+            className="inline-flex items-center gap-2 text-sm font-medium text-foreground transition hover:text-accent"
           >
             Show More
             <span aria-hidden>→</span>

--- a/frontend/src/app/gallery/_components/GalleryApp.tsx
+++ b/frontend/src/app/gallery/_components/GalleryApp.tsx
@@ -32,7 +32,7 @@ export default function GalleryApp({
   const initialLoadRef = useRef(true);
 
   const [focusedImageIndex, setFocusedImageIndex] = useState<number | null>(null);
-  const focusedImage = focusedImageIndex !== null ? images[focusedImageIndex] : null;
+  const focusedImage = focusedImageIndex !== null ? (images[focusedImageIndex] ?? null) : null;
 
   const hasPrevious = focusedImageIndex !== null && focusedImageIndex > 0;
   const hasNext = focusedImageIndex !== null && focusedImageIndex < images.length - 1;

--- a/frontend/src/app/projects/_components/ProjectCard.tsx
+++ b/frontend/src/app/projects/_components/ProjectCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type SyntheticEvent, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import Image from 'next/image';
 import type { ProjectType } from '@/utils/types';
 
@@ -14,12 +14,11 @@ export default function ProjectCard({ project }: ProjectCardProps) {
   const [imgFailed, setImgFailed] = useState(false);
 
   const handleError = useCallback(
-    (e: SyntheticEvent<HTMLImageElement>) => {
+    () => {
       if (imageSrc === project.thumbnail && project.file) {
         setImageSrc(project.file);
       } else {
         setImgFailed(true);
-        (e.target as HTMLImageElement).style.display = 'none';
       }
     },
     [imageSrc, project.thumbnail, project.file],
@@ -80,9 +79,9 @@ export default function ProjectCard({ project }: ProjectCardProps) {
   );
 
   const isSafeLink =
-    project.link?.startsWith('https://') || project.link?.startsWith('http://');
+    project.link.startsWith('https://') || project.link.startsWith('http://');
 
-  if (project.link && isSafeLink) {
+  if (isSafeLink) {
     return (
       <a
         href={project.link}

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -25,7 +25,7 @@ export type CategoryType = {
 export type ProjectType = {
   id: number;
   title: string;
-  link: string | null;
+  link: string;
   description: string | null;
   tags: string[];
   file: string | null;


### PR DESCRIPTION
## 概要

自動コード品質チェック（2026-07-31）で発見した軽微な問題を修正します。

## 変更内容

### フロントエンド

- **デザイントークン統一** (`GallerySection.tsx`, `ProjectsSection.tsx`)
  「Show More」リンクのhoverカラーが `text-blue-600` にハードコードされており、デザインシステムのaccentトークンから外れていました。`hover:text-accent` に統一しました。

- **型の正確化** (`types.ts`)
  `ProjectType.link` が `string | null` と定義されていましたが、DBの `null: false` 制約とモデルの `presence: true` バリデーションにより実態は常に `string` です。型を `string` に修正し、`ProjectCard.tsx` の冗長なnullチェック（`?.` オペレーター、`project.link &&`）を除去しました。

- **DOM直接操作の削除** (`ProjectCard.tsx`)
  画像ロードエラー時に `(e.target as HTMLImageElement).style.display = 'none'` でDOMを直接操作していましたが、直後の `setImgFailed(true)` によるReactの再レンダリングで同じ結果が得られるため、冗長かつ非慣用的なコードでした。削除し、`SyntheticEvent` の不要なインポートも合わせて除去しました。

- **型ガードの明確化** (`GalleryApp.tsx`)
  `images[focusedImageIndex]` が `undefined` を返す可能性を `?? null` で明示的にガードしました。

### バックエンド

- **重複viewportメタタグの削除** (`layouts/application.html.haml`)
  `<meta name="viewport">` が2行存在していました（内容はスペース違いのみ）。重複を削除しました。

- **ナビリンクをRailsルートヘルパーに変更** (`layouts/application.html.haml`)
  ナビゲーションリンクがハードコードされたhref文字列（`"/admin/images"` 等）を使用しており、ルート変更時に静かに壊れるリスクがありました。`admin_images_path` 等のルートヘルパーに変更しました（mountedエンジンのジョブリンクは除く）。

## 対応しなかった項目（別途検討推奨）

| # | 内容 | 理由 |
|---|------|------|
| HIGH | バリアントレコードN+1（API endpoints） | 影響範囲が大きくテスト変更を伴うため別PRで対応推奨 |
| HIGH | 孤立DBテーブル（`articles`, `publishments`） | マイグレーションによるテーブル削除は慎重に判断が必要 |
| MEDIUM | `error.tsx` / `global-error.tsx` の重複 | `global-error.tsx` の `<html><body>` ラッパー要件があり単純な共通化が困難 |
| LOW | `IndexController` でのインメモリgear集計 | コメントにYAGNI記載あり、現状データ量では問題なし |

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPnpcZhmw9MtG3t6ggjq7F)_