### PR TITLE
fix: コード品質チェック 2026-08-03

### DIFF
--- a/backend/db/migrate/20260803000000_drop_dead_articles_and_publishments_tables.rb
+++ b/backend/db/migrate/20260803000000_drop_dead_articles_and_publishments_tables.rb
@@ -1,0 +1,23 @@
+class DropDeadArticlesAndPublishmentsTables < ActiveRecord::Migration[8.0]
+  def up
+    # These tables were created in Oct 2024 for a blog/article feature that was
+    # never implemented. No models, controllers, routes, or application code
+    # references them. Drop the FK before the parent table.
+    remove_foreign_key :publishments, :articles
+    drop_table :publishments
+    drop_table :articles
+  end
+
+  def down
+    create_table :articles do |t|
+      t.string :title
+      t.text :body
+      t.timestamps
+    end
+
+    create_table :publishments do |t|
+      t.references :article, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/frontend/src/app/_components/GallerySection.tsx
+++ b/frontend/src/app/_components/GallerySection.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import ImageGrid from '@/app/gallery/_components/ImageGrid';
-import { fetchImages } from '@/utils/imageApi';
+import { fetchImages, IMAGE_REVALIDATE_SECONDS } from '@/utils/imageApi';
 
 export default async function GallerySection() {
-  const { images: previewImages, error } = await fetchImages({ limit: 9, fetchInit: { next: { revalidate: 120 } } });
+  const { images: previewImages, error } = await fetchImages({ limit: 9, fetchInit: { next: { revalidate: IMAGE_REVALIDATE_SECONDS } } });
 
   return (
     <section className="bg-background px-6 py-20 md:py-24 snap-ignore" aria-labelledby="gallery-heading">

--- a/frontend/src/app/_components/IntroSection.tsx
+++ b/frontend/src/app/_components/IntroSection.tsx
@@ -65,7 +65,7 @@ export default function IntroSection() {
                   key={label}
                   href={href}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-base px-4 py-2 text-sm font-medium text-foreground transition hover:-translate-y-0.5 hover:border-accent hover:text-accent"
                 >
                   <span className="flex h-8 w-8 items-center justify-center rounded-full bg-accent-light/40 text-accent">

--- a/frontend/src/app/_components/ProjectsSection.tsx
+++ b/frontend/src/app/_components/ProjectsSection.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import ProjectCard from '../projects/_components/ProjectCard';
-import { fetchProjects } from '@/utils/projectApi';
+import { fetchProjects, PROJECT_REVALIDATE_SECONDS } from '@/utils/projectApi';
 
 export default async function ProjectsSection() {
-  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: 300 } } });
+  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: PROJECT_REVALIDATE_SECONDS } } });
   return (
     <section className="bg-background px-6 py-20 md:py-24 snap-ignore" aria-labelledby="projects-heading">
       <div className="mx-auto w-full max-w-5xl">

--- a/frontend/src/app/gallery/_components/ImageModal.tsx
+++ b/frontend/src/app/gallery/_components/ImageModal.tsx
@@ -223,17 +223,20 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
           <div className="flex flex-wrap gap-4 text-xs text-gray-500">
             {image.camera_name && <span>Camera: {image.camera_name}</span>}
             {image.lens_name && <span>Lens: {image.lens_name}</span>}
-            {image.taken_at && (
-              <span>
-                {new Date(image.taken_at).toLocaleString('ja-JP', {
-                  year: 'numeric',
-                  month: '2-digit',
-                  day: '2-digit',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
-              </span>
-            )}
+            {image.taken_at && (() => {
+              const d = new Date(image.taken_at);
+              return !isNaN(d.getTime()) ? (
+                <span>
+                  {d.toLocaleString('ja-JP', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </span>
+              ) : null;
+            })()}
           </div>
         </div>
       </div>

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import SiteHeader from '../_components/SiteHeader';
 import GalleryApp from './_components/GalleryApp';
-import { fetchCategories } from '@/utils/categoryApi';
-import { fetchImages } from '@/utils/imageApi';
+import { fetchCategories, CATEGORY_REVALIDATE_SECONDS } from '@/utils/categoryApi';
+import { fetchImages, IMAGE_REVALIDATE_SECONDS } from '@/utils/imageApi';
 
 const description = '藤井駆陸が撮影した写真作品のギャラリー。フィールドワークの記録から日常のスナップまで、カテゴリ別に閲覧できます。';
 
@@ -17,8 +17,8 @@ export const metadata: Metadata = {
 
 export default async function Page() {
   const [categoriesResult, imagesResult] = await Promise.all([
-    fetchCategories({ fetchInit: { next: { revalidate: 300 } } }),
-    fetchImages({ fetchInit: { next: { revalidate: 120 } } }),
+    fetchCategories({ fetchInit: { next: { revalidate: CATEGORY_REVALIDATE_SECONDS } } }),
+    fetchImages({ fetchInit: { next: { revalidate: IMAGE_REVALIDATE_SECONDS } } }),
   ]);
 
   return (

--- a/frontend/src/app/projects/_components/ProjectApp.tsx
+++ b/frontend/src/app/projects/_components/ProjectApp.tsx
@@ -1,8 +1,8 @@
-import { fetchProjects } from '@/utils/projectApi';
+import { fetchProjects, PROJECT_REVALIDATE_SECONDS } from '@/utils/projectApi';
 import ProjectCard from './ProjectCard';
 
 export default async function ProjectApp() {
-  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: 300 } } });
+  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: PROJECT_REVALIDATE_SECONDS } } });
 
   return (
     <section className="mx-auto w-full max-w-6xl px-4 py-20">

--- a/frontend/src/utils/categoryApi.ts
+++ b/frontend/src/utils/categoryApi.ts
@@ -1,6 +1,8 @@
 import { apiFetch, type ApiRequestInit } from '@/utils/api';
 import type { CategoryType } from '@/utils/types';
 
+export const CATEGORY_REVALIDATE_SECONDS = 300;
+
 type FetchCategoriesOptions = {
   fetchInit?: ApiRequestInit;
 };

--- a/frontend/src/utils/imageApi.ts
+++ b/frontend/src/utils/imageApi.ts
@@ -1,6 +1,8 @@
 import { apiFetch, type ApiRequestInit } from '@/utils/api';
 import type { PaginatedImages } from '@/utils/types';
 
+export const IMAGE_REVALIDATE_SECONDS = 120;
+
 type FetchImagesOptions = {
   categoryIds?: number[];
   cursor?: string | null;

--- a/frontend/src/utils/projectApi.ts
+++ b/frontend/src/utils/projectApi.ts
@@ -1,6 +1,8 @@
 import { apiFetch, type ApiRequestInit } from '@/utils/api';
 import type { ProjectType } from '@/utils/types';
 
+export const PROJECT_REVALIDATE_SECONDS = 300;
+
 type FetchProjectsOptions = {
   fetchInit?: ApiRequestInit;
 };


### PR DESCRIPTION
## 概要

自動コード品質チェック（2026-08-03）で発見した問題の修正です。

## 変更内容

### セキュリティ
- **`IntroSection.tsx`**: ソーシャルリンクの `rel="noreferrer"` を `rel="noopener noreferrer"` に修正。モダンブラウザでは `noreferrer` が `noopener` を含意しますが、明示的に両方指定するのがベストプラクティスであり、`ProjectCard.tsx` の実装と統一されます。

### バグ修正（UX）
- **`ImageModal.tsx`**: `taken_at` の日付表示で `new Date(image.taken_at)` が `Invalid Date` を返しうる問題を修正。`isNaN(d.getTime())` によるガードを追加し、不正な日付文字列の場合は何も表示しません。

### 保守性
- **`imageApi.ts` / `projectApi.ts` / `categoryApi.ts`**: キャッシュ再検証の秒数（`revalidate: 120` / `revalidate: 300`）がコンポーネント間で重複していた問題を修正。`IMAGE_REVALIDATE_SECONDS`・`PROJECT_REVALIDATE_SECONDS`・`CATEGORY_REVALIDATE_SECONDS` として各 API モジュールに定数を定義し、以下の呼び出し箇所で参照するよう統一：
  - `GallerySection.tsx`
  - `gallery/page.tsx`
  - `ProjectsSection.tsx`
  - `ProjectApp.tsx`

### スキーマ整理（バックエンド）
- **新規マイグレーション**: 2024-10 に作成されたまま使われていない `articles` / `publishments` テーブルを削除。対応するモデル・コントローラ・ルート・シード・テストは一切存在しないことを確認済み。`down` メソッドに再作成 SQL を記述しているためロールバック可能です。

## 変更なしの指摘事項（参考）

以下はチェックで発見しましたが、今回の PR には含めていません：

| 項目 | 理由 |
|------|------|
| `api.ts` の `response.json() as T` に実行時バリデーションなし | zod 等のスキーマ検証導入は設計判断を伴うため別途議論が必要 |
| `/api/*` エンドポイントへのレート制限なし | インフラ（Cloudflare）での対応が適切 |
| `Admin::IndexController` の `Camera.count(&:uncurated?)` が Ruby 側で全件集計 | コメントに YAGNI と明記されており、現在の件数で問題なし |
| `ImageGalleryOrdering#feature!` の count/write 競合 | DB レベルの UNIQUE 制約追加が必要で影響範囲が大きい |
| `ImageType.file` / `ProjectType.file` の命名がURLを表すのに紛らわしい | API の後方互換を伴うリネームのため別途検討 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcictAVNnizWPp1tfs24S6)_