### PR TITLE
学生生活やりたいことリスト（/todo・いいね・admin 管理）を追加

### DIFF
--- a/backend/app/controllers/admin/todo_items_controller.rb
+++ b/backend/app/controllers/admin/todo_items_controller.rb
@@ -1,0 +1,64 @@
+class Admin::TodoItemsController < Admin::Base
+  before_action :set_todo_item, only: %i[edit update destroy insert_at]
+
+  def index
+    @todo_items = TodoItem.ordered
+  end
+
+  def new
+    @todo_item = TodoItem.new
+  end
+
+  def edit; end
+
+  def create
+    @todo_item = TodoItem.new(todo_item_params)
+    @todo_item.position = TodoItem.next_position
+    if @todo_item.save
+      redirect_to admin_todo_items_path, notice: 'TodoItem was successfully created.'
+    else
+      flash.now[:alert] = 'TodoItem failed to create.'
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    if @todo_item.update(todo_item_params)
+      redirect_to admin_todo_items_path, notice: 'TodoItem was successfully updated.'
+    else
+      flash.now[:alert] = 'TodoItem failed to update.'
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def insert_at
+    ids = TodoItem.ordered.where.not(id: @todo_item.id).pluck(:id)
+    ids.insert(insert_params.to_i.clamp(0, ids.size), @todo_item.id)
+    TodoItem.reorder_positions!(ids)
+    head :ok
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+    render json: { error: e.message }, status: :unprocessable_content
+  end
+
+  def destroy
+    if @todo_item.destroy
+      redirect_to admin_todo_items_path, notice: 'TodoItem was successfully destroyed.'
+    else
+      redirect_to admin_todo_items_path, alert: 'TodoItem failed to destroy.'
+    end
+  end
+
+  private
+
+  def set_todo_item
+    @todo_item = TodoItem.find(params[:id])
+  end
+
+  def todo_item_params
+    params.expect(todo_item: %i[title note done published])
+  end
+
+  def insert_params
+    params.require(:position)
+  end
+end

--- a/backend/app/controllers/api/todo_items_controller.rb
+++ b/backend/app/controllers/api/todo_items_controller.rb
@@ -1,0 +1,15 @@
+class Api::TodoItemsController < ApplicationController
+  def index
+    items = TodoItem.published.ordered
+    liked_ids = liked_item_ids(items)
+    render json: items.map { |item| item.api_json(liked: liked_ids.include?(item.id)) }
+  end
+
+  private
+
+  def liked_item_ids(items)
+    return Set.new if params[:device_uuid].blank?
+
+    TodoLike.where(todo_item: items, device_uuid: params[:device_uuid]).pluck(:todo_item_id).to_set
+  end
+end

--- a/backend/app/controllers/api/todo_likes_controller.rb
+++ b/backend/app/controllers/api/todo_likes_controller.rb
@@ -1,0 +1,27 @@
+class Api::TodoLikesController < ApplicationController
+  # cross-origin SPA からの呼び出しで session cookie を使わないため CSRF 対象外
+  skip_forgery_protection
+
+  before_action :set_todo_item
+
+  def create
+    like = @todo_item.todo_likes.create_or_find_by!(device_uuid: params[:device_uuid])
+    # 既にいいね済みなら counter は動いていないので再取得しない
+    @todo_item.reload if like.previously_new_record?
+    render json: @todo_item.api_json(liked: true)
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
+  end
+
+  def destroy
+    removed = @todo_item.todo_likes.find_by(device_uuid: params[:device_uuid])&.destroy!
+    @todo_item.reload if removed
+    render json: @todo_item.api_json(liked: false)
+  end
+
+  private
+
+  def set_todo_item
+    @todo_item = TodoItem.published.find(params[:todo_item_id])
+  end
+end

--- a/backend/app/javascript/controllers/auto_submit_controller.js
+++ b/backend/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * form 要素に付けて、配下の input の change で即送信する
+ * （例: admin todo_items index の達成チェックボックス）
+ *
+ *   %form{ data: { controller: 'auto-submit' } }
+ *     %input{ data: { action: 'change->auto-submit#submit' } }
+ */
+export default class extends Controller {
+  submit() {
+    this.element.requestSubmit()
+  }
+}

--- a/backend/app/javascript/controllers/sortable_controller.js
+++ b/backend/app/javascript/controllers/sortable_controller.js
@@ -2,9 +2,15 @@ import { Controller } from '@hotwired/stimulus'
 
 /**
  * Sortable.js を利用してリストの並び替えを実装する
+ *
+ * 使う側の view で以下を指定する:
+ * - data-sortable-url-value: `:id` プレースホルダ入りの insert_at パス
+ *   （例: insert_at_admin_todo_item_path(':id')）
+ * - 各行に data-sortable-id
  */
 export default class extends Controller {
   static targets = ['list']
+  static values = { url: String }
 
   connect() {
     this._orderBeforeDrag = []
@@ -15,6 +21,7 @@ export default class extends Controller {
       // pointer ベースのフォールバックに固定して挙動を一貫させる（E2E も安定する）。
       forceFallback: true,
       ghostClass: 'sortable-ghost',
+      dataIdAttr: 'data-sortable-id',
       onStart: () => { this._orderBeforeDrag = this.sortable.toArray() },
       onEnd: this.onSortEnd.bind(this)
     })
@@ -29,7 +36,7 @@ export default class extends Controller {
    */
   async onSortEnd(evt) {
     const { item, newIndex } = evt
-    const itemId = item.dataset.imageId
+    const itemId = item.dataset.sortableId
     const savedOrder = this._orderBeforeDrag
 
     try {
@@ -61,7 +68,7 @@ export default class extends Controller {
   }
 
   async #updatePosition(itemId, position) {
-    const response = await fetch(`/admin/images/${itemId}/insert_at`, {
+    const response = await fetch(this.urlValue.replace(':id', itemId), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/backend/app/models/todo_item.rb
+++ b/backend/app/models/todo_item.rb
@@ -1,0 +1,30 @@
+class TodoItem < ApplicationRecord
+  has_many :todo_likes, dependent: :destroy
+
+  validates :title, presence: true
+  validates :position, presence: true, numericality: { only_integer: true }
+
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(:position, :id) }
+
+  # 新規作成時の採番用。position は admin index のドラッグでのみ変更する
+  def self.next_position
+    (maximum(:position) || -1) + 1
+  end
+
+  # admin index のドラッグ並び替えから呼ばれ、渡された順で position を 0..N-1 に振り直す
+  def self.reorder_positions!(ids)
+    items = where(id: ids).index_by(&:id)
+    raise ActiveRecord::RecordNotFound, 'Some todo items not found' if items.size != ids.uniq.size
+
+    transaction do
+      ids.each_with_index { |id, index| items.fetch(id).update!(position: index) }
+    end
+  end
+
+  # 公開 API のレスポンス表現。一覧といいねトグルの2エンドポイントで
+  # 同じ shape を返すためここに一本化する
+  def api_json(liked:)
+    as_json(only: %i[id title note done likes_count]).merge(liked: liked)
+  end
+end

--- a/backend/app/models/todo_like.rb
+++ b/backend/app/models/todo_like.rb
@@ -1,0 +1,9 @@
+class TodoLike < ApplicationRecord
+  belongs_to :todo_item, counter_cache: :likes_count
+
+  # device_uuid はフロント生成の識別子。形式は強制しないが、公開エンドポイント
+  # なので長さだけ制限する。重複防止は DB の unique index が担う
+  # （uniqueness バリデーションを足すと create_or_find_by! が DB に届く前に
+  #  RecordInvalid になり冪等にならない）
+  validates :device_uuid, presence: true, length: { maximum: 64 }
+end

--- a/backend/app/views/admin/images/arrange.html.haml
+++ b/backend/app/views/admin/images/arrange.html.haml
@@ -6,7 +6,7 @@
 
 - if @images.any?
   .table-responsive
-    %table.table.table-hover{ data: { controller: 'sortable' } }
+    %table.table.table-hover{ data: { controller: 'sortable', sortable_url_value: insert_at_admin_image_path(':id') } }
       %thead
         %tr
           %th 表示順
@@ -14,7 +14,7 @@
           %th タイトル
       %tbody{ data: { "sortable-target": "list" } }
         - @images.each_with_index do |image, index|
-          %tr{"data-image-id": image.id}
+          %tr{"data-sortable-id": image.id}
             %td.handle.cursor-grab.user-select-none
               %span.material-symbols-outlined.text-muted.me-1 drag_indicator
               %span.order-number= index + 1

--- a/backend/app/views/admin/todo_items/_form.html.haml
+++ b/backend/app/views/admin/todo_items/_form.html.haml
@@ -1,0 +1,25 @@
+= form_with(model: todo_item, url: todo_item.new_record? ? admin_todo_items_path : admin_todo_item_path(todo_item), local: true) do |form|
+  - if todo_item.errors.any?
+    .alert.alert-danger
+      %ul
+        - todo_item.errors.full_messages.each do |message|
+          %li= message
+  .row.mb-3
+    .col-md-3.col-form-label.fw-bold title
+    .col-md-9= form.text_field :title, class: 'form-control'
+  .row.mb-3
+    .col-md-3.col-form-label.fw-bold note
+    .col-md-9
+      = form.text_area :note, rows: 3, class: 'form-control'
+      %small.text-muted 補足があれば（公開ページにも表示される）
+  .row.mb-3
+    .col-md-3.col-form-label.fw-bold done
+    .col-md-9.d-flex.align-items-center
+      = form.check_box :done, class: 'form-check-input'
+  .row.mb-3
+    .col-md-3.col-form-label.fw-bold published
+    .col-md-9.d-flex.align-items-center
+      = form.check_box :published, class: 'form-check-input'
+  .row
+    .col
+      = form.submit '保存', class: 'btn btn-primary d-block w-100'

--- a/backend/app/views/admin/todo_items/edit.html.haml
+++ b/backend/app/views/admin/todo_items/edit.html.haml
@@ -1,0 +1,2 @@
+%h1 やりたいこと編集
+= render 'form', todo_item: @todo_item

--- a/backend/app/views/admin/todo_items/index.html.haml
+++ b/backend/app/views/admin/todo_items/index.html.haml
@@ -1,0 +1,32 @@
+%h1 やりたいことリスト
+
+%p.text-muted.small 達成チェックは即保存。行はドラッグで並び替えでき、即保存されます。
+
+.table-responsive
+  %table.table.table-striped{ data: { controller: 'sortable', sortable_url_value: insert_at_admin_todo_item_path(':id') } }
+    %thead
+      %tr
+        %th 達成
+        %th
+        %th タイトル
+        %th メモ
+        %th 公開
+        %th いいね
+        %th 編集
+        %th 削除
+    %tbody{ data: { "sortable-target": "list" } }
+      - @todo_items.each do |item|
+        %tr{ "data-sortable-id": item.id }
+          %td
+            = form_with(model: item, url: admin_todo_item_path(item), method: :patch, data: { controller: 'auto-submit' }) do |form|
+              = form.check_box :done, class: 'form-check-input', data: { action: 'change->auto-submit#submit' }
+          %td.handle.cursor-grab.user-select-none
+            %span.material-symbols-outlined.text-muted drag_indicator
+          %td{ class: item.done ? 'text-muted' : nil }= item.title
+          %td= item.note.present? ? truncate(item.note, length: 40) : 'ー'
+          %td= item.published ? '公開' : '非公開'
+          %td= item.likes_count
+          %td= link_to '編集', edit_admin_todo_item_path(item), class: 'btn btn-secondary btn-sm'
+          %td= button_to '削除', admin_todo_item_path(item), method: :delete, data: { turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger btn-sm'
+
+= link_to '新規作成', new_admin_todo_item_path, class: 'btn btn-primary mt-3'

--- a/backend/app/views/admin/todo_items/new.html.haml
+++ b/backend/app/views/admin/todo_items/new.html.haml
@@ -1,0 +1,2 @@
+%h1 やりたいこと新規作成
+= render 'form', todo_item: @todo_item

--- a/backend/app/views/layouts/application.html.haml
+++ b/backend/app/views/layouts/application.html.haml
@@ -34,6 +34,8 @@
               = link_to 'カテゴリ', admin_categories_path, class: 'nav-link'
             %li.nav-item
               = link_to 'プロジェクト', admin_projects_path, class: 'nav-link'
+            %li.nav-item
+              = link_to 'やりたいこと', admin_todo_items_path, class: 'nav-link'
             - if failed_job_count.positive?
               %li.nav-item
                 %a.nav-link{:href => "/admin/jobs"}

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -3,6 +3,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins ENV['FRONTEND_ORIGIN'] || "http://localhost:3002"
     resource "/api/*",
              headers: %w[Content-Type Accept Authorization],
-             methods: %i[get options head]
+             # /api 配下は書き込みエンドポイント（いいね等）を含むため GET 系以外も許可
+             methods: %i[get post delete options head]
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
     resources :lenses, except: %i[index show]
     resources :categories
     resources :projects
+    resources :todo_items do
+      post :insert_at, on: :member
+    end
   end
   # ジョブダッシュボード（認証は Admin::Base 経由、config/application.rb 参照）
   mount MissionControl::Jobs::Engine, at: "/admin/jobs"
@@ -29,5 +32,8 @@ Rails.application.routes.draw do
     resources :images, only: %i[index]
     resources :categories, only: %i[index]
     resources :projects, only: %i[index]
+    resources :todo_items, only: %i[index] do
+      resource :like, only: %i[create destroy], controller: 'todo_likes'
+    end
   end
 end

--- a/backend/db/migrate/20260805000000_create_todo_items_and_todo_likes.rb
+++ b/backend/db/migrate/20260805000000_create_todo_items_and_todo_likes.rb
@@ -1,0 +1,25 @@
+# 学生生活やりたいことリスト（公開ページ /todo + admin 管理）。
+# likes_count は todo_likes からの導出値だが、一覧表示のたびに COUNT しないよう
+# Rails 標準 counter_cache で materialize する。
+class CreateTodoItemsAndTodoLikes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :todo_items do |t|
+      t.string :title, null: false
+      t.text :note
+      t.integer :position, null: false, default: 0
+      t.boolean :done, null: false, default: false
+      t.boolean :published, null: false, default: true
+      t.integer :likes_count, null: false, default: 0
+      t.timestamps
+    end
+
+    create_table :todo_likes do |t|
+      # 単独 index は複合 unique index の左端 prefix で代替できるため張らない
+      t.references :todo_item, null: false, foreign_key: true, index: false
+      t.string :device_uuid, null: false
+      t.timestamps
+    end
+    # 「1デバイス1いいね」をサーバ側で担保する本体
+    add_index :todo_likes, %i[todo_item_id device_uuid], unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_09_020000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -239,6 +239,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_020000) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "todo_items", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "done", default: false, null: false
+    t.integer "likes_count", default: 0, null: false
+    t.text "note"
+    t.integer "position", default: 0, null: false
+    t.boolean "published", default: true, null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "todo_likes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "device_uuid", null: false
+    t.bigint "todo_item_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["todo_item_id", "device_uuid"], name: "index_todo_likes_on_todo_item_id_and_device_uuid", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -265,4 +284,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_020000) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "todo_likes", "todo_items"
 end

--- a/backend/spec/factories/todo_item.rb
+++ b/backend/spec/factories/todo_item.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :todo_item do
+    title { Faker::Lorem.sentence(word_count: 3) }
+    position { 0 }
+  end
+end

--- a/backend/spec/factories/todo_like.rb
+++ b/backend/spec/factories/todo_like.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :todo_like do
+    todo_item
+    device_uuid { SecureRandom.uuid }
+  end
+end

--- a/backend/spec/models/todo_item_spec.rb
+++ b/backend/spec/models/todo_item_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe TodoItem do
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:position) }
+  it { is_expected.to have_many(:todo_likes).dependent(:destroy) }
+end

--- a/backend/spec/models/todo_like_spec.rb
+++ b/backend/spec/models/todo_like_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe TodoLike do
+  subject { build(:todo_like) }
+
+  it { is_expected.to validate_presence_of(:device_uuid) }
+
+  it 'rejects duplicate likes at the DB level' do
+    like = create(:todo_like)
+    expect do
+      create(:todo_like, todo_item: like.todo_item, device_uuid: like.device_uuid)
+    end.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it 'keeps likes_count in sync on create and destroy' do
+    item = create(:todo_item)
+    like = create(:todo_like, todo_item: item)
+    expect(item.reload.likes_count).to eq(1)
+
+    like.destroy!
+    expect(item.reload.likes_count).to eq(0)
+  end
+end

--- a/backend/spec/requests/admin/images_spec.rb
+++ b/backend/spec/requests/admin/images_spec.rb
@@ -71,12 +71,10 @@ RSpec.describe 'Admin::Images', type: :request do
       get '/admin/images/arrange'
 
       expect(response).to have_http_status(:success)
-      expect(response.body)
-        .to include("data-image-id='#{featured.id}'").or include("data-image-id=\"#{featured.id}\"")
+      expect(response.body).to match(/data-sortable-id=['"]#{featured.id}['"]/)
       # 下書き・非 featured の公開画像は並び替え画面に出さない（featured のみの鏡）
       [draft, image1].each do |image|
-        expect(response.body).not_to include("data-image-id='#{image.id}'")
-        expect(response.body).not_to include("data-image-id=\"#{image.id}\"")
+        expect(response.body).not_to match(/data-sortable-id=['"]#{image.id}['"]/)
       end
     end
   end

--- a/backend/spec/requests/admin/todo_items_spec.rb
+++ b/backend/spec/requests/admin/todo_items_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+RSpec.describe 'Admin::TodoItems', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:user, :admin) }
+
+  before do
+    sign_in admin
+  end
+
+  describe 'GET /admin/todo_items' do
+    it 'renders the sortable list with done checkboxes' do
+      item = create(:todo_item, title: '富士山に登る', done: true)
+
+      get admin_todo_items_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('富士山に登る')
+      expect(response.body).to match(/data-sortable-id=['"]#{item.id}['"]/)
+      expect(response.body).to include('todo_item[done]')
+    end
+  end
+
+  describe 'POST /admin/todo_items' do
+    it 'creates a todo item appended to the end' do
+      create(:todo_item, position: 5)
+
+      expect do
+        post admin_todo_items_path, params: { todo_item: { title: '富士山に登る' } }
+      end.to change(TodoItem, :count).by(1)
+
+      expect(response).to redirect_to(admin_todo_items_path)
+      expect(TodoItem.find_by(title: '富士山に登る').position).to eq(6)
+    end
+
+    it 'rejects a blank title' do
+      post admin_todo_items_path, params: { todo_item: { title: '' } }
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe 'PATCH /admin/todo_items/:id' do
+    it 'toggles done (index の達成チェックボックス相当)' do
+      item = create(:todo_item, done: false)
+
+      patch admin_todo_item_path(item), params: { todo_item: { done: true } }
+
+      expect(response).to redirect_to(admin_todo_items_path)
+      expect(item.reload.done).to be(true)
+    end
+  end
+
+  describe 'POST /admin/todo_items/:id/insert_at' do
+    it 'moves the item to the given position and renumbers 0..N-1' do
+      first = create(:todo_item, position: 0)
+      second = create(:todo_item, position: 1)
+      third = create(:todo_item, position: 2)
+
+      post insert_at_admin_todo_item_path(third), params: { position: 0 }
+
+      expect(response).to have_http_status(:ok)
+      expect(TodoItem.ordered.pluck(:id)).to eq([third.id, first.id, second.id])
+      expect(TodoItem.ordered.pluck(:position)).to eq([0, 1, 2])
+    end
+
+    it 'clamps an out-of-range position to the end' do
+      first = create(:todo_item, position: 0)
+      second = create(:todo_item, position: 1)
+
+      post insert_at_admin_todo_item_path(first), params: { position: 99 }
+
+      expect(response).to have_http_status(:ok)
+      expect(TodoItem.ordered.pluck(:id)).to eq([second.id, first.id])
+    end
+  end
+end

--- a/backend/spec/requests/api/todo_items_spec.rb
+++ b/backend/spec/requests/api/todo_items_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe 'TodoItems API', type: :request do
+  describe 'GET /api/todo_items' do
+    let!(:second_item) { create(:todo_item, title: 'Second', position: 2) }
+    let!(:first_item) { create(:todo_item, title: 'First', position: 1, done: true) }
+
+    before { create(:todo_item, title: 'Hidden', published: false) }
+
+    it 'returns published items ordered by position' do
+      get '/api/todo_items'
+      expect(response).to have_http_status(:success)
+
+      items = response.parsed_body
+      expect(items.pluck('title')).to eq(%w[First Second])
+      expect(items.first).to include('done' => true, 'likes_count' => 0, 'liked' => false)
+    end
+
+    it 'marks items liked by the given device' do
+      create(:todo_like, todo_item: first_item, device_uuid: 'device-1')
+      create(:todo_like, todo_item: second_item, device_uuid: 'other-device')
+
+      get '/api/todo_items', params: { device_uuid: 'device-1' }
+
+      liked_flags = response.parsed_body.to_h { |item| [item['title'], item['liked']] }
+      expect(liked_flags).to eq('First' => true, 'Second' => false)
+    end
+  end
+
+  describe 'POST /api/todo_items/:todo_item_id/like' do
+    let!(:item) { create(:todo_item) }
+
+    it 'adds at most one like per device' do
+      expect do
+        2.times { post "/api/todo_items/#{item.id}/like", params: { device_uuid: 'device-1' } }
+      end.to change { item.reload.likes_count }.by(1)
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include('likes_count' => 1, 'liked' => true)
+    end
+
+    it 'rejects a blank device_uuid' do
+      post "/api/todo_items/#{item.id}/like"
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'returns 404 for an unpublished item' do
+      hidden = create(:todo_item, published: false)
+      post "/api/todo_items/#{hidden.id}/like", params: { device_uuid: 'device-1' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'DELETE /api/todo_items/:todo_item_id/like' do
+    let!(:item) { create(:todo_item) }
+
+    it 'removes the like of the device' do
+      create(:todo_like, todo_item: item, device_uuid: 'device-1')
+
+      delete "/api/todo_items/#{item.id}/like", params: { device_uuid: 'device-1' }
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include('likes_count' => 0, 'liked' => false)
+      expect(item.reload.likes_count).to eq(0)
+    end
+
+    it 'is a no-op when the device has not liked' do
+      delete "/api/todo_items/#{item.id}/like", params: { device_uuid: 'device-1' }
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include('likes_count' => 0, 'liked' => false)
+    end
+  end
+end

--- a/e2e/tests/admin/a-image-sort.spec.ts
+++ b/e2e/tests/admin/a-image-sort.spec.ts
@@ -5,16 +5,16 @@ test.describe('Image Sort', () => {
     await page.goto('/admin/images/arrange');
 
     // Verify seed images exist
-    await expect(page.locator('tr[data-image-id]', { hasText: 'Seed Image 1' })).toBeVisible();
-    await expect(page.locator('tr[data-image-id]', { hasText: 'Seed Image 2' })).toBeVisible();
-    await expect(page.locator('tr[data-image-id]', { hasText: 'Seed Image 3' })).toBeVisible();
+    await expect(page.locator('tr[data-sortable-id]', { hasText: 'Seed Image 1' })).toBeVisible();
+    await expect(page.locator('tr[data-sortable-id]', { hasText: 'Seed Image 2' })).toBeVisible();
+    await expect(page.locator('tr[data-sortable-id]', { hasText: 'Seed Image 3' })).toBeVisible();
 
     // Verify drag handles exist
     await expect(page.locator('.handle').first()).toBeVisible();
 
     // Get the drag handle of Seed Image 3 and the target row (Seed Image 1)
-    const sourceRow = page.locator('tr[data-image-id]', { hasText: 'Seed Image 3' });
-    const targetRow = page.locator('tr[data-image-id]', { hasText: 'Seed Image 1' });
+    const sourceRow = page.locator('tr[data-sortable-id]', { hasText: 'Seed Image 3' });
+    const targetRow = page.locator('tr[data-sortable-id]', { hasText: 'Seed Image 1' });
     const handle = sourceRow.locator('.handle');
 
     // Use explicit mouse operations for more reliable drag and drop

--- a/frontend/src/app/todo/_components/TodoApp.tsx
+++ b/frontend/src/app/todo/_components/TodoApp.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { fetchTodoItems, setTodoItemLike } from '@/utils/todoApi';
+import type { TodoItemType } from '@/utils/types';
+
+const DEVICE_UUID_STORAGE_KEY = 'todo-device-uuid';
+
+// module レベルで memoize し、localStorage が使えない環境（プライベートモード等）
+// でもセッション内は同じ UUID を返す
+let cachedDeviceUuid: string | null = null;
+
+function getDeviceUuid(): string {
+  if (cachedDeviceUuid) return cachedDeviceUuid;
+  try {
+    const stored = window.localStorage.getItem(DEVICE_UUID_STORAGE_KEY);
+    if (stored) {
+      cachedDeviceUuid = stored;
+    } else {
+      cachedDeviceUuid = window.crypto.randomUUID();
+      window.localStorage.setItem(DEVICE_UUID_STORAGE_KEY, cachedDeviceUuid);
+    }
+  } catch {
+    cachedDeviceUuid = window.crypto.randomUUID();
+  }
+  return cachedDeviceUuid;
+}
+
+function HeartIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="h-5 w-5"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+    </svg>
+  );
+}
+
+// 訪問者は操作できない、達成状態を示す表示専用の大きなチェックボックス
+function DoneCheckbox({ done }: { done: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`flex h-7 w-7 shrink-0 items-center justify-center rounded border-2 ${
+        done
+          ? 'border-neutral-400 bg-neutral-400 dark:border-neutral-500 dark:bg-neutral-500'
+          : 'border-foreground'
+      }`}
+    >
+      {done && (
+        <svg
+          viewBox="0 0 24 24"
+          className="h-5 w-5 text-background"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      )}
+    </span>
+  );
+}
+
+type TodoAppProps = {
+  initialItems: TodoItemType[];
+  initialFetchError: boolean;
+};
+
+export default function TodoApp({ initialItems, initialFetchError }: TodoAppProps) {
+  const [items, setItems] = useState<TodoItemType[]>(initialItems);
+  const [fetchError, setFetchError] = useState(initialFetchError);
+
+  // マウント後に device_uuid 付きで取り直し、liked フラグを反映する
+  useEffect(() => {
+    let cancelled = false;
+    fetchTodoItems({ deviceUuid: getDeviceUuid() }).then((result) => {
+      if (cancelled || result.error) return;
+      setItems(result.items);
+      setFetchError(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggleLike = useCallback(async (item: TodoItemType) => {
+    const nextLiked = !item.liked;
+
+    // optimistic update。失敗したらタップ前のスナップショット（item）に戻す
+    setItems((prev) =>
+      prev.map((i) =>
+        i.id === item.id
+          ? { ...i, liked: nextLiked, likes_count: i.likes_count + (nextLiked ? 1 : -1) }
+          : i,
+      ),
+    );
+
+    const result = await setTodoItemLike(item.id, getDeviceUuid(), nextLiked);
+    const next = result.error ? item : result.data;
+    setItems((prev) => prev.map((i) => (i.id === item.id ? next : i)));
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-2xl px-5 py-12 md:py-16">
+      <header className="mb-6 md:mb-8">
+        <h1 className="text-2xl font-bold md:text-3xl">学生生活やりたいことリスト</h1>
+        <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+          学生のうちにやっておきたいことたち。♥ で応援できます。
+        </p>
+      </header>
+
+      {fetchError && items.length === 0 && (
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          リストを読み込めませんでした。時間をおいて再読み込みしてください。
+        </p>
+      )}
+      {!fetchError && items.length === 0 && (
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">まだ項目がありません。</p>
+      )}
+
+      <ul className="divide-y divide-black/10 dark:divide-white/10">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-center gap-4 py-4">
+            <DoneCheckbox done={item.done} />
+            <div className="min-w-0 flex-1">
+              {/* text-base は使わない: @theme の --color-base により色ユーティリティに解決され白文字になる */}
+              <p
+                className={`font-medium md:text-lg ${
+                  item.done ? 'text-neutral-500 dark:text-neutral-400' : ''
+                }`}
+              >
+                {item.title}
+              </p>
+              {item.note && (
+                <p className="mt-0.5 text-sm text-neutral-500 dark:text-neutral-400">{item.note}</p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => toggleLike(item)}
+              aria-pressed={item.liked}
+              aria-label={item.liked ? 'いいねを取り消す' : 'いいねする'}
+              className={`flex shrink-0 items-center gap-1 py-1 text-sm transition-colors ${
+                item.liked
+                  ? 'text-accent'
+                  : 'text-neutral-400 hover:text-accent dark:text-neutral-500'
+              }`}
+            >
+              <HeartIcon filled={item.liked} />
+              <span className="tabular-nums">{item.likes_count}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/app/todo/page.tsx
+++ b/frontend/src/app/todo/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { fetchTodoItems } from '@/utils/todoApi';
+import TodoApp from './_components/TodoApp';
+
+export const metadata: Metadata = {
+  title: 'やりたいことリスト',
+  description: '学生生活でやりたいことリスト',
+  alternates: {
+    canonical: '/todo',
+  },
+};
+
+export default async function TodoPage() {
+  // liked はデバイス依存なので server では取れない。クライアント側で
+  // device_uuid 付きで再取得して上書きする
+  const { items, error } = await fetchTodoItems({
+    fetchInit: { next: { revalidate: 60 } },
+  });
+
+  return <TodoApp initialItems={items} initialFetchError={error} />;
+}

--- a/frontend/src/utils/todoApi.test.ts
+++ b/frontend/src/utils/todoApi.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchTodoItems, setTodoItemLike } from './todoApi';
+
+vi.mock('@/utils/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/utils/api';
+const mockApiFetch = vi.mocked(apiFetch);
+
+const baseItem = {
+  id: 1,
+  title: '富士山に登る',
+  note: null,
+  done: false,
+  likes_count: 0,
+  liked: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('fetchTodoItems', () => {
+  it('requests without device_uuid when none is given', async () => {
+    mockApiFetch.mockResolvedValue({ data: [baseItem], error: false });
+
+    const result = await fetchTodoItems();
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/todo_items', 'todo items', undefined);
+    expect(result).toEqual({ items: [baseItem], error: false });
+  });
+
+  it('appends the encoded device_uuid to the query', async () => {
+    mockApiFetch.mockResolvedValue({ data: [], error: false });
+
+    await fetchTodoItems({ deviceUuid: 'abc/123' });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/todo_items?device_uuid=abc%2F123',
+      'todo items',
+      undefined,
+    );
+  });
+
+  it('returns empty items on error', async () => {
+    mockApiFetch.mockResolvedValue({ data: null, error: true });
+
+    const result = await fetchTodoItems();
+    expect(result).toEqual({ items: [], error: true });
+  });
+});
+
+describe('setTodoItemLike', () => {
+  it('POSTs when liking and returns the updated item', async () => {
+    const updated = { ...baseItem, likes_count: 1, liked: true };
+    mockApiFetch.mockResolvedValue({ data: updated, error: false });
+
+    const result = await setTodoItemLike(1, 'device-1', true);
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/todo_items/1/like?device_uuid=device-1', 'todo like', {
+      method: 'POST',
+    });
+    expect(result).toEqual({ data: updated, error: false });
+  });
+
+  it('DELETEs when unliking', async () => {
+    mockApiFetch.mockResolvedValue({ data: baseItem, error: false });
+
+    const result = await setTodoItemLike(1, 'device-1', false);
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/todo_items/1/like?device_uuid=device-1', 'todo like', {
+      method: 'DELETE',
+    });
+    expect(result).toEqual({ data: baseItem, error: false });
+  });
+
+  it('passes the error result through', async () => {
+    mockApiFetch.mockResolvedValue({ data: null, error: true });
+
+    const result = await setTodoItemLike(1, 'device-1', true);
+    expect(result).toEqual({ data: null, error: true });
+  });
+});

--- a/frontend/src/utils/todoApi.ts
+++ b/frontend/src/utils/todoApi.ts
@@ -1,0 +1,37 @@
+import { apiFetch, type ApiRequestInit, type ApiResult } from '@/utils/api';
+import type { TodoItemType } from '@/utils/types';
+
+type FetchTodoItemsOptions = {
+  deviceUuid?: string;
+  fetchInit?: ApiRequestInit;
+};
+
+type FetchTodoItemsResult = {
+  items: TodoItemType[];
+  error: boolean;
+};
+
+export async function fetchTodoItems({
+  deviceUuid,
+  fetchInit,
+}: FetchTodoItemsOptions = {}): Promise<FetchTodoItemsResult> {
+  const query = deviceUuid ? `?device_uuid=${encodeURIComponent(deviceUuid)}` : '';
+  const result = await apiFetch<TodoItemType[]>(`/todo_items${query}`, 'todo items', fetchInit);
+  if (result.error) {
+    return { items: [], error: true };
+  }
+  return { items: result.data, error: false };
+}
+
+// device_uuid は body ではなく query で送る（Rails 側で DELETE の body パースに
+// 依存しないようにし、POST/DELETE を対称にする）。成功時は更新後のアイテム全体が返る
+export async function setTodoItemLike(
+  id: number,
+  deviceUuid: string,
+  liked: boolean,
+): Promise<ApiResult<TodoItemType>> {
+  const query = `?device_uuid=${encodeURIComponent(deviceUuid)}`;
+  return apiFetch<TodoItemType>(`/todo_items/${id}/like${query}`, 'todo like', {
+    method: liked ? 'POST' : 'DELETE',
+  });
+}

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -22,6 +22,15 @@ export type CategoryType = {
   name: string;
 };
 
+export type TodoItemType = {
+  id: number;
+  title: string;
+  note: string | null;
+  done: boolean;
+  likes_count: number;
+  liked: boolean;
+};
+
 export type ProjectType = {
   id: number;
   title: string;


### PR DESCRIPTION
## 概要
kakemu.work/todo に公開のやりたいことリストを追加し、admin から CRUD・達成チェック・ドラッグ並び替え、訪問者から1デバイス1回のいいねができるようにする。

## レビュー優先度
🔴 全文レビュー — 新機能（新テーブル・公開書き込みエンドポイント・CORS 変更を含む）

## 判断・トレードオフ
- **いいねの重複防止**: localStorage の device UUID + `todo_likes(todo_item_id, device_uuid)` unique index。モデルに uniqueness バリデーションは意図的に置かない（`create_or_find_by!` が DB に届く前に RecordInvalid になり冪等性が壊れるため。DB 制約が単一ソース）
- **position の単一ソース化**: 並び順は admin index のドラッグのみで管理。フォームの position 入力は持たず、新規作成は末尾に自動採番
- **sortable_controller の汎用化**: images 固有だった URL / 行 ID を data 属性化して todo と共用。これに伴い arrange 画面と e2e のセレクタを `data-sortable-id` に変更（e2e は CI で検証される）
- **CORS**: `/api/*` の methods に post/delete を追加（いいね用。resource 単位で分けるより共有設定の一般化を選択）
- **frontend の `text-base` 禁止**: `@theme` の `--color-base` と衝突して色ユーティリティ（白文字）に解決されるため使用していない

## 確認
- RSpec 209件 / RuboCop / ESLint / Vitest 40件 / next build すべて green
- dev 実機で確認済み: /todo の描画（達成グレー階調・ダーク対応クラス）、いいねの冪等性（POST 2連発で 1 のまま・DELETE・blank uuid 422 を curl で確認）、admin の達成チェック即保存、insert_at による並び替えと復元
- 未確認: ドラッグの生ジェスチャのみ手動未実施（永続化経路は検証済み。images と同一 controller で e2e が CI で走る）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)