### PR TITLE
routes.rb を Metrics/BlockLength から除外（main CI 修正）

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -47,3 +47,5 @@ Metrics/PerceivedComplexity:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+    # 宣言的 DSL で行数が複雑さを意味しないため（routes は今後も伸びる）
+    - 'config/routes.rb'


### PR DESCRIPTION
## 概要
#349 merge 後の main の Backend CI（rubocop フルスキャン）が `config/routes.rb` の Metrics/BlockLength (31/25) で落ちたため、routes.rb を除外する。

## レビュー優先度
🟢 レビュー不要 — rubocop 設定の1行変更のみ

## 確認
- ローカルでフルスキャン `bundle exec rubocop` → 101 files, no offenses

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)