### PR TITLE
fix: JSDoc コメントの todo→bucket_list 更新、device_uuid をログフィルタに追加

### DIFF
--- a/backend/app/javascript/controllers/auto_submit_controller.js
+++ b/backend/app/javascript/controllers/auto_submit_controller.js
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 
 /**
  * form 要素に付けて、配下の input の change で即送信する
- * （例: admin todo_items index の達成チェックボックス）
+ * （例: admin bucket_list_items index の達成チェックボックス）
  *
  *   %form{ data: { controller: 'auto-submit' } }
  *     %input{ data: { action: 'change->auto-submit#submit' } }

--- a/backend/app/javascript/controllers/sortable_controller.js
+++ b/backend/app/javascript/controllers/sortable_controller.js
@@ -5,7 +5,7 @@ import { Controller } from '@hotwired/stimulus'
  *
  * 使う側の view で以下を指定する:
  * - data-sortable-url-value: `:id` プレースホルダ入りの insert_at パス
- *   （例: insert_at_admin_todo_item_path(':id')）
+ *   （例: insert_at_admin_bucket_list_item_path(':id')）
  * - 各行に data-sortable-id
  */
 export default class extends Controller {

--- a/backend/config/initializers/filter_parameter_logging.rb
+++ b/backend/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  passw secret token _key crypt salt certificate otp ssn email
+  passw secret token _key crypt salt certificate otp ssn email device_uuid
 ]


### PR DESCRIPTION
## 概要

定期コード品質チェック（2026-08-07）で検出した2件の軽微な問題を修正します。

### 1. JSDoc コメントの古いルート名を修正

`todo` → `bucket_list` リネーム後も、Stimulus コントローラの JSDoc 例示に旧ルート名が残っていました。

- `auto_submit_controller.js`: `admin todo_items` → `admin bucket_list_items`
- `sortable_controller.js`: `insert_at_admin_todo_item_path` → `insert_at_admin_bucket_list_item_path`

### 2. `device_uuid` をパラメータフィルタに追加

バケットリスト「いいね」機能の公開エンドポイントはクエリパラメータとして `device_uuid`（ブラウザ生成の訪問者識別子）を受け取ります。現状では Rails ログに平文で記録されるため、`filter_parameters` に追加してマスクされるようにしました。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NA3jxauxoHLnWLmCRbVYFx)_