### PR TITLE
refactor: サイトのメタ情報を名前先行のミニマルな内容に整理する

### DIFF
--- a/frontend/src/app/bucket-list/page.tsx
+++ b/frontend/src/app/bucket-list/page.tsx
@@ -2,11 +2,18 @@ import type { Metadata } from 'next';
 import { fetchBucketListItems } from '@/utils/bucketListApi';
 import BucketListApp from './_components/BucketListApp';
 
+// 単体で共有されることを前提にしたページなので、og も親任せにせず個別に持たせる
+const description = '藤井駆陸が学生のうちにやっておきたいことのリスト。達成状況を公開しています。♥ で応援できます。';
+
 export const metadata: Metadata = {
-  title: 'やりたいことリスト',
-  description: '学生生活でやりたいことリスト',
+  title: '学生生活やりたいことリスト',
+  description,
   alternates: {
     canonical: '/bucket-list',
+  },
+  openGraph: {
+    title: '学生生活やりたいことリスト | Kakemu Fujii',
+    description,
   },
 };
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,10 +11,13 @@ const geistSans = localFont({
 
 const siteUrl = getSiteUrl();
 
+/** og:site_name が SITE.name なので、og:title は別の文字列にしないとカードの 2 行が重複する */
+const ogTitle = `${SITE.nameJa}のポートフォリオ`;
+
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: {
-    default: SITE.name,
+    default: `${SITE.nameJa} | ${SITE.name}`,
     template: `%s | ${SITE.name}`,
   },
   description: SITE.description,
@@ -22,7 +25,7 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   openGraph: {
-    title: SITE.name,
+    title: ogTitle,
     description: SITE.description,
     url: siteUrl,
     siteName: SITE.name,
@@ -39,21 +42,23 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: SITE.name,
+    title: ogTitle,
     description: SITE.description,
     creator: "@k4kemu",
-    images: ["/og-image.jpg"],
+    images: [{ url: "/og-image.jpg", alt: SITE.name }],
   },
 };
 
 const personJsonLd = {
   "@context": "https://schema.org",
   "@type": "Person",
-  name: SITE.name,
+  name: SITE.nameJa,
+  alternateName: SITE.name,
   url: siteUrl,
   image: `${siteUrl}/icon_kakemu.jpg`,
-  jobTitle: "Researcher / Web Developer / Photographer",
+  jobTitle: ["Researcher", "Web Developer", "Photographer"],
   description: SITE.description,
+  // 表示上の説明からは研究の話を外したが、エンティティとしての強さは JSON-LD 側で維持する
   affiliation: {
     "@type": "CollegeOrUniversity",
     name: "Kyoto University",

--- a/frontend/src/utils/site.ts
+++ b/frontend/src/utils/site.ts
@@ -10,9 +10,14 @@ export function getSiteUrl(): string {
 
 export const SITE = {
   name: 'Kakemu Fujii',
-  /** 京大で昆虫の研究をしながら web 開発と写真をやっている、が伝わる説明 */
+  /** 日本語表記。「藤井駆陸」と「kakemu」どちらの名前検索でも拾えるよう title に併記する */
+  nameJa: '藤井駆陸',
+  /**
+   * 名前を先頭に置く。Google のモバイル SERP は全角 50 字前後で切られるため、
+   * 後ろに置くと最有力の流入経路である名前検索で名前が表示されないまま切れる。
+   */
   description:
-    '京都大学で昆虫が葉につける食痕を研究する傍ら、web 開発と写真撮影をしている藤井駆陸のポートフォリオ。プロジェクトと写真作品をまとめています。',
+    '藤井駆陸（Kakemu Fujii）のポートフォリオ。web 開発のプロジェクトと写真作品をまとめています。',
   locale: 'ja_JP',
   /** JSON-LD Person / OGP profile に使う SNS プロフィール URL */
   socialLinks: [


### PR DESCRIPTION
## 概要
meta description から研究の記述を外して名前先頭に整理し、埋め込みカードで重複していた og:title を og:site_name と分離する。

## レビュー優先度
🟡 動作確認のみ — ロジック変更なし。ただし表示される文言そのものなので、head 出力の実物確認は必要。

## 判断・トレードオフ

**description は名前を先頭に置く**
Google のモバイル SERP は全角 50 字前後で切られる。変更前の文は `京都大学で昆虫が葉につける食痕を研究する傍ら、web 開発と写真撮…` で切れ、最有力の流入経路である名前検索（「藤井駆陸」「kakemu」）で肝心の名前が表示されないまま終わっていた。

**研究のキーワードを description から外すのはほぼノーリスク**
「昆虫」「食痕」等は競合の少ないロングテール語だが、About セクション本文（`IntroSection.tsx`）に生テキストで残るためインデックスからは消えない。失うのは description 内での重み付けだけ。

**og:title を og:site_name と別文字列にする**
どちらも `SITE.name` だったため、Slack / Discord のカードで上 2 行が `Kakemu Fujii` / `Kakemu Fujii` と重複していた。site_name はサイト名、og:title は「何のページか」に役割を分ける。

**JSON-LD には affiliation と Researcher を残す**
表示上の説明はミニマルにしつつ、エンティティとしての強さは構造化データ側で維持する。見た目の簡潔さと SEO のトレードオフを回避する意図。

**bucket-list に og を個別に持たせる**
単体で共有される前提のページなので、og を親からの継承任せにしない。title も画面の h1 に揃えた。

## 確認
`yarn tsc --noEmit` 通過。メタ情報を参照しているテストはなし。
**実際の `<head>` 出力は未確認** — dev サーバーを立てていないため。マージ前に OGP デバッガ等で実物を見てもらいたい。

## 関連
favicon の不足（apple-icon 180 / SVG / manifest）はデザイン作業を伴うため #357 に分離した。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)