### PR TITLE
fix: コード品質チェック 2026-08-10

### DIFF
--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -4,7 +4,7 @@ class Admin::ImagesController < Admin::Base
 
   PER_PAGE = 50
 
-  before_action :set_cameras_and_lenses_and_categories, only: %i[new edit create update]
+  before_action :set_cameras_and_lenses_and_categories, only: %i[index new edit create update]
   before_action :set_image, only: %i[show edit update destroy insert_at]
   before_action :set_adjacent_images, only: %i[edit update]
 

--- a/backend/app/controllers/admin/images_controller.rb
+++ b/backend/app/controllers/admin/images_controller.rb
@@ -4,7 +4,7 @@ class Admin::ImagesController < Admin::Base
 
   PER_PAGE = 50
 
-  before_action :set_cameras_and_lenses_and_categories, only: %i[index new edit create update]
+  before_action :set_cameras_and_lenses_and_categories, only: %i[new edit create update]
   before_action :set_image, only: %i[show edit update destroy insert_at]
   before_action :set_adjacent_images, only: %i[edit update]
 

--- a/e2e/tests/admin/admin-access.spec.ts
+++ b/e2e/tests/admin/admin-access.spec.ts
@@ -25,7 +25,8 @@ test.describe('Admin Access', () => {
 
     // Login as guest
     const guestEmail = process.env.E2E_GUEST_EMAIL ?? 'guest@example.com';
-    const guestPassword = process.env.E2E_GUEST_PASSWORD ?? 'password123';
+    const guestPassword = process.env.E2E_GUEST_PASSWORD;
+    if (!guestPassword) throw new Error('E2E_GUEST_PASSWORD is required');
     await page.goto('/users/sign_in');
     await page.getByRole('textbox', { name: 'Email' }).fill(guestEmail);
     await page.getByRole('textbox', { name: 'Password' }).fill(guestPassword);

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -5,7 +5,8 @@ const authFile = path.join(__dirname, '..', '.auth', 'admin.json');
 
 setup('authenticate as admin', async ({ page }) => {
   const email = process.env.E2E_ADMIN_EMAIL ?? 'admin@example.com';
-  const password = process.env.E2E_ADMIN_PASSWORD ?? 'password123';
+  const password = process.env.E2E_ADMIN_PASSWORD;
+  if (!password) throw new Error('E2E_ADMIN_PASSWORD is required');
 
   await page.goto('/users/sign_in');
 

--- a/frontend/src/app/_components/SiteHeader.tsx
+++ b/frontend/src/app/_components/SiteHeader.tsx
@@ -5,8 +5,8 @@ import { usePathname } from 'next/navigation';
 import Header from '@/ui/Header';
 import { HEADER_STYLE_PRESETS } from '@/ui/headerStyles';
 
-type SiteHeaderMode = 'auto' | 'solid' | 'light';
-type HeaderVariant = 'light' | 'solid';
+type SiteHeaderMode = 'auto' | keyof typeof HEADER_STYLE_PRESETS;
+type HeaderVariant = keyof typeof HEADER_STYLE_PRESETS;
 
 type SiteHeaderProps = {
   mode?: SiteHeaderMode;

--- a/frontend/src/app/bucket-list/_components/BucketListApp.tsx
+++ b/frontend/src/app/bucket-list/_components/BucketListApp.tsx
@@ -83,11 +83,13 @@ export default function BucketListApp({ initialItems, initialFetchError }: Bucke
   // マウント後に device_uuid 付きで取り直し、liked フラグを反映する
   useEffect(() => {
     let cancelled = false;
-    fetchBucketListItems({ deviceUuid: getDeviceUuid() }).then((result) => {
-      if (cancelled || result.error) return;
-      setItems(result.items);
-      setFetchError(false);
-    });
+    fetchBucketListItems({ deviceUuid: getDeviceUuid() })
+      .then((result) => {
+        if (cancelled || result.error) return;
+        setItems(result.items);
+        setFetchError(false);
+      })
+      .catch(() => {});
     return () => {
       cancelled = true;
     };

--- a/frontend/src/app/gallery/_components/CategoryCheckbox.test.tsx
+++ b/frontend/src/app/gallery/_components/CategoryCheckbox.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CategoryCheckbox from './CategoryCheckbox';
-import { CategoryType } from '@/utils/types';
+import type { CategoryType } from '@/utils/types';
 
 const category: CategoryType = {
   id: 1,

--- a/frontend/src/app/gallery/_components/ImageModal.tsx
+++ b/frontend/src/app/gallery/_components/ImageModal.tsx
@@ -204,7 +204,6 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
               height={displayHeight}
               sizes="(min-width: 1024px) 60vw, 90vw"
               className="h-auto max-h-[70vh] w-auto object-contain"
-              priority={false}
               onError={handleImgError}
             />
           )}


### PR DESCRIPTION
## 変更内容

定期コード品質チェック（2026-08-10）で発見した問題を修正します。

### セキュリティ
- **E2E テストのパスワードハードコードを削除**（`e2e/tests/auth.setup.ts`、`e2e/tests/admin/admin-access.spec.ts`）
  - `'password123'` というフォールバック値がソースに残っており、リポジトリを見た人がデフォルトパスワードを推測できる状態だった
  - 環境変数が未設定の場合は明示的な例外をスローするよう変更

### パフォーマンス
- **admin/images: `set_cameras_and_lenses_and_categories` を `:index` から除外**（`backend/app/controllers/admin/images_controller.rb`）
  - index 画面では `@cameras`、`@lenses`、`@categories` は使用されないが、`before_action` に `:index` が含まれていたため毎回 3 クエリが余分に走っていた

### エラーハンドリング
- **BucketListApp: useEffect 内の Promise に `.catch()` を追加**（`frontend/src/app/bucket-list/_components/BucketListApp.tsx`）
  - `fetchBucketListItems` または `getDeviceUuid` が予期せず throw した場合に unhandled rejection 警告が出る可能性があった

### 型安全性・クリーンアップ
- **`CategoryCheckbox.test.tsx`**: `import { CategoryType }` を `import type { CategoryType }` に修正（型インポートの明示）
- **`ImageModal.tsx`**: `priority={false}` は Next.js `<Image>` のデフォルト値と同一のため削除
- **`SiteHeader.tsx`**: `HeaderVariant` 型を `'light' | 'solid'` の手書きリテラルから `keyof typeof HEADER_STYLE_PRESETS` に変更し、`headerStyles.ts` が単一ソースとなるよう修正

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qqw69EunSnAs1wBRZZq1mU)_