### PR TITLE
fix: コード品質 PR 5本を精査して1本にまとめる

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,8 +29,18 @@ RUN bundle install && \
 
 COPY . .
 
+# assets:precompile は RAILS_ENV=production で boot するため、本番で fail-fast する
+# 設定（cdn.rb / cors.rb の ENV.fetch、storage.yml の s3_prod）がすべて評価される。
+# ビルド時には実際の値を渡せないので、ここではダミーを与えて boot だけ通す。
+# 値の検証は実行時（コンテナ起動時）の同じ ENV.fetch が担う。
 RUN bundle exec bootsnap precompile app/ lib/ && \
-    SECRET_KEY_BASE_DUMMY=1 CLOUDFRONT_BASE_URL=https://dummy ./bin/rails assets:precompile
+    SECRET_KEY_BASE_DUMMY=1 \
+    CLOUDFRONT_BASE_URL=https://dummy \
+    FRONTEND_ORIGIN=https://dummy \
+    AWS_ACCESS_KEY_ID=dummy \
+    AWS_SECRET_ACCESS_KEY=dummy \
+    AWS_BUCKET=dummy-bucket \
+    ./bin/rails assets:precompile
 
 
 # Final stage for app image

--- a/backend/app/controllers/api/images_controller.rb
+++ b/backend/app/controllers/api/images_controller.rb
@@ -26,7 +26,7 @@ class Api::ImagesController < ApplicationController
   def next_cursor(image)
     if image.featured_rank.present?
       "f,#{image.featured_rank},#{image.id}"
-    else
+    elsif image.taken_at
       "t,#{(image.taken_at.to_f * 1000).floor},#{image.id}"
     end
   end

--- a/backend/app/javascript/controllers/auto_submit_controller.js
+++ b/backend/app/javascript/controllers/auto_submit_controller.js
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 
 /**
  * form 要素に付けて、配下の input の change で即送信する
- * （例: admin todo_items index の達成チェックボックス）
+ * （例: admin bucket_list_items index の達成チェックボックス）
  *
  *   %form{ data: { controller: 'auto-submit' } }
  *     %input{ data: { action: 'change->auto-submit#submit' } }

--- a/backend/app/javascript/controllers/sortable_controller.js
+++ b/backend/app/javascript/controllers/sortable_controller.js
@@ -5,7 +5,7 @@ import { Controller } from '@hotwired/stimulus'
  *
  * 使う側の view で以下を指定する:
  * - data-sortable-url-value: `:id` プレースホルダ入りの insert_at パス
- *   （例: insert_at_admin_todo_item_path(':id')）
+ *   （例: insert_at_admin_bucket_list_item_path(':id')）
  * - 各行に data-sortable-id
  */
 export default class extends Controller {

--- a/backend/app/models/camera.rb
+++ b/backend/app/models/camera.rb
@@ -10,7 +10,7 @@ class Camera < ApplicationRecord
   def self.resolve_from_exif(make:, model:)
     return nil if make.blank? || model.blank?
 
-    find_or_create_by!(make: make, model: model) do |camera|
+    create_or_find_by!(make: make, model: model) do |camera|
       camera.manufacturer = make
       camera.name = model
     end

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -2,5 +2,5 @@ class Category < ApplicationRecord
   has_many :image_categories, dependent: :destroy
   has_many :images, through: :image_categories
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/backend/app/models/concerns/cdn_attached_file.rb
+++ b/backend/app/models/concerns/cdn_attached_file.rb
@@ -49,7 +49,7 @@ module CdnAttachedFile
     ensure_variant_processed(variant)
 
     build_cdn_url(variant.key) || active_storage_url_for(variant)
-  rescue StandardError, LoadError => e
+  rescue StandardError => e
     # error 固定（warn からの意図的な格上げ）: 2026-06-18 の S3 アップロード失敗インシデントでは
     # variant_generated? が DB のみを見るため silent fallback が唯一の手がかりだった。
     # variant_key / blob_id を含めて grep・件数集計できるようにする（storage:verify_variants と対）。

--- a/backend/app/models/lens.rb
+++ b/backend/app/models/lens.rb
@@ -9,7 +9,7 @@ class Lens < ApplicationRecord
   def self.resolve_from_exif(exif_name)
     return nil if exif_name.blank?
 
-    find_or_create_by!(exif_name: exif_name) { |lens| lens.name = exif_name }
+    create_or_find_by!(exif_name: exif_name) { |lens| lens.name = exif_name }
   end
 
   # EXIF 自動生成のまま表示名を整えていない機材を「未整備」とする。

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['FRONTEND_ORIGIN'] || "http://localhost:3002"
+    origins Rails.env.production? ? ENV.fetch('FRONTEND_ORIGIN') : (ENV['FRONTEND_ORIGIN'] || "http://localhost:3002")
     resource "/api/*",
              headers: %w[Content-Type Accept Authorization],
              # /api 配下は書き込みエンドポイント（いいね等）を含むため GET 系以外も許可

--- a/backend/config/initializers/filter_parameter_logging.rb
+++ b/backend/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  passw secret token _key crypt salt certificate otp ssn email
+  passw secret token _key crypt salt certificate otp ssn email device_uuid
 ]

--- a/backend/config/storage.yml
+++ b/backend/config/storage.yml
@@ -16,8 +16,8 @@ s3_dev:
 
 s3_prod:
   service: S3
-  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] || "dummy" %>
-  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] || "dummy" %>
+  access_key_id: <%= Rails.env.production? ? ENV.fetch("AWS_ACCESS_KEY_ID") : (ENV["AWS_ACCESS_KEY_ID"] || "dummy") %>
+  secret_access_key: <%= Rails.env.production? ? ENV.fetch("AWS_SECRET_ACCESS_KEY") : (ENV["AWS_SECRET_ACCESS_KEY"] || "dummy") %>
   region: <%= ENV["AWS_REGION"] || "ap-northeast-1" %>
-  bucket: <%= ENV["AWS_BUCKET"] || "dummy-bucket" %>
+  bucket: <%= Rails.env.production? ? ENV.fetch("AWS_BUCKET") : (ENV["AWS_BUCKET"] || "dummy-bucket") %>
   public: false

--- a/backend/db/migrate/20260814000000_add_unique_index_to_categories_name.rb
+++ b/backend/db/migrate/20260814000000_add_unique_index_to_categories_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToCategoriesName < ActiveRecord::Migration[8.1]
+  def change
+    add_index :categories, :name, unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -83,6 +83,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
   create_table "image_categories", force: :cascade do |t|

--- a/e2e/tests/admin/admin-access.spec.ts
+++ b/e2e/tests/admin/admin-access.spec.ts
@@ -25,7 +25,8 @@ test.describe('Admin Access', () => {
 
     // Login as guest
     const guestEmail = process.env.E2E_GUEST_EMAIL ?? 'guest@example.com';
-    const guestPassword = process.env.E2E_GUEST_PASSWORD ?? 'password123';
+    const guestPassword = process.env.E2E_GUEST_PASSWORD;
+    if (!guestPassword) throw new Error('E2E_GUEST_PASSWORD is required');
     await page.goto('/users/sign_in');
     await page.getByRole('textbox', { name: 'Email' }).fill(guestEmail);
     await page.getByRole('textbox', { name: 'Password' }).fill(guestPassword);

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -5,7 +5,8 @@ const authFile = path.join(__dirname, '..', '.auth', 'admin.json');
 
 setup('authenticate as admin', async ({ page }) => {
   const email = process.env.E2E_ADMIN_EMAIL ?? 'admin@example.com';
-  const password = process.env.E2E_ADMIN_PASSWORD ?? 'password123';
+  const password = process.env.E2E_ADMIN_PASSWORD;
+  if (!password) throw new Error('E2E_ADMIN_PASSWORD is required');
 
   await page.goto('/users/sign_in');
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -53,6 +53,19 @@ const nextConfig: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForDev: process.env.TURBOPACK_FS_CACHE !== '0',
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [{ source: '/todo', destination: '/bucket-list', permanent: true }];
   },

--- a/frontend/src/app/_components/GallerySection.tsx
+++ b/frontend/src/app/_components/GallerySection.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import ImageGrid from '@/app/gallery/_components/ImageGrid';
-import { fetchImages } from '@/utils/imageApi';
+import { fetchImages, IMAGE_REVALIDATE_SECONDS } from '@/utils/imageApi';
 
 export default async function GallerySection() {
-  const { images: previewImages, error } = await fetchImages({ limit: 9, fetchInit: { next: { revalidate: 120 } } });
+  const { images: previewImages, error } = await fetchImages({ limit: 9, fetchInit: { next: { revalidate: IMAGE_REVALIDATE_SECONDS } } });
 
   return (
     <section className="bg-background px-6 py-20 md:py-24 snap-ignore" aria-labelledby="gallery-heading">

--- a/frontend/src/app/_components/IntroSection.tsx
+++ b/frontend/src/app/_components/IntroSection.tsx
@@ -65,7 +65,7 @@ export default function IntroSection() {
                   key={label}
                   href={href}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-base px-4 py-2 text-sm font-medium text-foreground transition hover:-translate-y-0.5 hover:border-accent hover:text-accent"
                 >
                   <span className="flex h-8 w-8 items-center justify-center rounded-full bg-accent-light/40 text-accent">

--- a/frontend/src/app/_components/ProjectsSection.tsx
+++ b/frontend/src/app/_components/ProjectsSection.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import ProjectCard from '../projects/_components/ProjectCard';
-import { fetchProjects } from '@/utils/projectApi';
+import { fetchProjects, PROJECT_REVALIDATE_SECONDS } from '@/utils/projectApi';
 
 export default async function ProjectsSection() {
-  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: 300 } } });
+  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: PROJECT_REVALIDATE_SECONDS } } });
   return (
     <section className="bg-background px-6 py-20 md:py-24 snap-ignore" aria-labelledby="projects-heading">
       <div className="mx-auto w-full max-w-5xl">

--- a/frontend/src/app/_components/SiteHeader.tsx
+++ b/frontend/src/app/_components/SiteHeader.tsx
@@ -5,8 +5,8 @@ import { usePathname } from 'next/navigation';
 import Header from '@/ui/Header';
 import { HEADER_STYLE_PRESETS } from '@/ui/headerStyles';
 
-type SiteHeaderMode = 'auto' | 'solid' | 'light';
-type HeaderVariant = 'light' | 'solid';
+type SiteHeaderMode = 'auto' | keyof typeof HEADER_STYLE_PRESETS;
+type HeaderVariant = keyof typeof HEADER_STYLE_PRESETS;
 
 type SiteHeaderProps = {
   mode?: SiteHeaderMode;

--- a/frontend/src/app/bucket-list/_components/BucketListApp.tsx
+++ b/frontend/src/app/bucket-list/_components/BucketListApp.tsx
@@ -83,11 +83,17 @@ export default function BucketListApp({ initialItems, initialFetchError }: Bucke
   // マウント後に device_uuid 付きで取り直し、liked フラグを反映する
   useEffect(() => {
     let cancelled = false;
-    fetchBucketListItems({ deviceUuid: getDeviceUuid() }).then((result) => {
-      if (cancelled || result.error) return;
-      setItems(result.items);
-      setFetchError(false);
-    });
+    fetchBucketListItems({ deviceUuid: getDeviceUuid() })
+      .then((result) => {
+        if (cancelled || result.error) return;
+        setItems(result.items);
+        setFetchError(false);
+      })
+      .catch((error: unknown) => {
+        // 握りつぶさず必ず残す。items が空のときだけエラー UI が出る（下の分岐参照）
+        console.error('bucket list の再取得に失敗しました', error);
+        if (!cancelled) setFetchError(true);
+      });
     return () => {
       cancelled = true;
     };

--- a/frontend/src/app/gallery/_components/CategoryCheckbox.test.tsx
+++ b/frontend/src/app/gallery/_components/CategoryCheckbox.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CategoryCheckbox from './CategoryCheckbox';
-import { CategoryType } from '@/utils/types';
+import type { CategoryType } from '@/utils/types';
 
 const category: CategoryType = {
   id: 1,

--- a/frontend/src/app/gallery/_components/ImageGrid.tsx
+++ b/frontend/src/app/gallery/_components/ImageGrid.tsx
@@ -142,7 +142,7 @@ export default function ImageGrid({
   }, [hasMore, onLoadMore]);
 
   if (isLoading) {
-    return <Loading label="Loading images..." className="py-20" />;
+    return <Loading label="読み込み中..." className="py-20" />;
   }
 
   const isClickable = Boolean(onFocus);
@@ -202,7 +202,7 @@ export default function ImageGrid({
       </div>
       {hasMore && (
         <div ref={sentinelRef} className="flex justify-center py-8">
-          {isLoadingMore && <Loading label="Loading more..." />}
+          {isLoadingMore && <Loading label="追加読み込み中..." />}
         </div>
       )}
     </>

--- a/frontend/src/app/gallery/_components/ImageModal.tsx
+++ b/frontend/src/app/gallery/_components/ImageModal.tsx
@@ -9,7 +9,7 @@ import { useIsClient } from '@/hooks/useIsClient';
 const FOCUSABLE_SELECTORS =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-type Props = {
+type ImageModalProps = {
   image: ImageType | null;
   onClose: () => void;
   onNext: () => void;
@@ -18,7 +18,7 @@ type Props = {
   hasPrevious: boolean;
 };
 
-export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext, hasPrevious }: Props) {
+export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext, hasPrevious }: ImageModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const titleId = useId();
   const descriptionId = useId();
@@ -128,6 +128,19 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
   const displayWidth = typeof image.width === 'number' && image.width > 0 ? image.width : 1600;
   const displayHeight = typeof image.height === 'number' && image.height > 0 ? image.height : 1066;
 
+  // 不正な日付文字列を new Date に渡すと Invalid Date になり "Invalid Date" が表示される
+  const takenAt = image.taken_at ? new Date(image.taken_at) : null;
+  const takenAtLabel =
+    takenAt && !Number.isNaN(takenAt.getTime())
+      ? takenAt.toLocaleString('ja-JP', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+        })
+      : null;
+
   const modalContent = (
     // Overlay
     <div
@@ -143,7 +156,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
       {/* Close button */}
       <button
         type="button"
-        aria-label="Close"
+        aria-label="閉じる"
         className="absolute top-4 right-4 text-3xl text-white cursor-pointer select-none"
         onClick={(event) => {
           event.stopPropagation();
@@ -157,7 +170,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
       {hasPrevious && (
         <button
           type="button"
-          aria-label="Previous"
+          aria-label="前の画像"
           className="absolute left-0 top-0 bottom-0 w-16 sm:w-24 flex items-center justify-center cursor-pointer group"
           onClick={(event) => {
             event.stopPropagation();
@@ -172,7 +185,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
       {hasNext && (
         <button
           type="button"
-          aria-label="Next"
+          aria-label="次の画像"
           className="absolute right-0 top-0 bottom-0 w-16 sm:w-24 flex items-center justify-center cursor-pointer group"
           onClick={(event) => {
             event.stopPropagation();
@@ -204,7 +217,6 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
               height={displayHeight}
               sizes="(min-width: 1024px) 60vw, 90vw"
               className="h-auto max-h-[70vh] w-auto object-contain"
-              priority={false}
               onError={handleImgError}
             />
           )}
@@ -223,17 +235,7 @@ export default function ImageModal({ image, onClose, onNext, onPrevious, hasNext
           <div className="flex flex-wrap gap-4 text-xs text-gray-500">
             {image.camera_name && <span>Camera: {image.camera_name}</span>}
             {image.lens_name && <span>Lens: {image.lens_name}</span>}
-            {image.taken_at && (
-              <span>
-                {new Date(image.taken_at).toLocaleString('ja-JP', {
-                  year: 'numeric',
-                  month: '2-digit',
-                  day: '2-digit',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
-              </span>
-            )}
+            {takenAtLabel && <span>{takenAtLabel}</span>}
           </div>
         </div>
       </div>

--- a/frontend/src/app/gallery/page.tsx
+++ b/frontend/src/app/gallery/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import SiteHeader from '../_components/SiteHeader';
 import GalleryApp from './_components/GalleryApp';
-import { fetchCategories } from '@/utils/categoryApi';
-import { fetchImages } from '@/utils/imageApi';
+import { fetchCategories, CATEGORY_REVALIDATE_SECONDS } from '@/utils/categoryApi';
+import { fetchImages, IMAGE_REVALIDATE_SECONDS } from '@/utils/imageApi';
 
 const description = '藤井駆陸が撮影した写真作品のギャラリー。フィールドワークの記録から日常のスナップまで、カテゴリ別に閲覧できます。';
 
@@ -17,8 +17,8 @@ export const metadata: Metadata = {
 
 export default async function Page() {
   const [categoriesResult, imagesResult] = await Promise.all([
-    fetchCategories({ fetchInit: { next: { revalidate: 300 } } }),
-    fetchImages({ fetchInit: { next: { revalidate: 120 } } }),
+    fetchCategories({ fetchInit: { next: { revalidate: CATEGORY_REVALIDATE_SECONDS } } }),
+    fetchImages({ fetchInit: { next: { revalidate: IMAGE_REVALIDATE_SECONDS } } }),
   ]);
 
   return (

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -87,7 +87,10 @@ export default function RootLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify([personJsonLd, websiteJsonLd]).replace(/</g, '\\u003c'),
+            __html: JSON.stringify([personJsonLd, websiteJsonLd])
+              .replace(/</g, '\\u003c')
+              .replace(/>/g, '\\u003e')
+              .replace(/&/g, '\\u0026'),
           }}
         />
         {children}

--- a/frontend/src/app/projects/_components/ProjectApp.tsx
+++ b/frontend/src/app/projects/_components/ProjectApp.tsx
@@ -1,8 +1,8 @@
-import { fetchProjects } from '@/utils/projectApi';
+import { fetchProjects, PROJECT_REVALIDATE_SECONDS } from '@/utils/projectApi';
 import ProjectCard from './ProjectCard';
 
 export default async function ProjectApp() {
-  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: 300 } } });
+  const { projects, error } = await fetchProjects({ fetchInit: { next: { revalidate: PROJECT_REVALIDATE_SECONDS } } });
 
   return (
     <section className="mx-auto w-full max-w-6xl px-4 py-20">

--- a/frontend/src/app/projects/_components/ProjectCard.tsx
+++ b/frontend/src/app/projects/_components/ProjectCard.tsx
@@ -41,7 +41,6 @@ export default function ProjectCard({ project }: ProjectCardProps) {
             fill
             sizes="(min-width: 768px) 33vw, 100vw"
             className="object-contain object-center"
-            priority={false}
             onError={handleError}
           />
         ) : (
@@ -78,13 +77,15 @@ export default function ProjectCard({ project }: ProjectCardProps) {
     </>
   );
 
-  const isSafeLink =
-    project.link.startsWith('https://') || project.link.startsWith('http://');
+  // ローカル const に受けてから判定する。project.link のままだと TS が
+  // isSafeLink 経由の絞り込みを href まで伝播できず string | null が残る
+  const link = project.link;
+  const isSafeLink = link !== null && (link.startsWith('https://') || link.startsWith('http://'));
 
   if (isSafeLink) {
     return (
       <a
-        href={project.link}
+        href={link}
         target="_blank"
         rel="noopener noreferrer"
         aria-label={`Open ${project.title} in a new tab`}

--- a/frontend/src/utils/categoryApi.ts
+++ b/frontend/src/utils/categoryApi.ts
@@ -1,6 +1,8 @@
 import { apiFetch, type ApiRequestInit } from '@/utils/api';
 import type { CategoryType } from '@/utils/types';
 
+export const CATEGORY_REVALIDATE_SECONDS = 300;
+
 type FetchCategoriesOptions = {
   fetchInit?: ApiRequestInit;
 };

--- a/frontend/src/utils/imageApi.ts
+++ b/frontend/src/utils/imageApi.ts
@@ -1,6 +1,8 @@
 import { apiFetch, type ApiRequestInit } from '@/utils/api';
 import type { PaginatedImages } from '@/utils/types';
 
+export const IMAGE_REVALIDATE_SECONDS = 120;
+
 type FetchImagesOptions = {
   categoryIds?: number[];
   cursor?: string | null;

--- a/frontend/src/utils/projectApi.ts
+++ b/frontend/src/utils/projectApi.ts
@@ -1,6 +1,8 @@
 import { apiFetch, type ApiRequestInit } from '@/utils/api';
 import type { ProjectType } from '@/utils/types';
 
+export const PROJECT_REVALIDATE_SECONDS = 300;
+
 type FetchProjectsOptions = {
   fetchInit?: ApiRequestInit;
 };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -34,7 +34,7 @@ export type BucketListItemType = {
 export type ProjectType = {
   id: number;
   title: string;
-  link: string;
+  link: string | null;
   description: string | null;
   tags: string[];
   file: string | null;


### PR DESCRIPTION
## 概要

滞留していたコード品質 PR **#347 #348 #356 #359 #369** を精査し、重複と自己 revert を除いたうえで 1 本に統合する。CI を 5 セット回さずに済ませるのが主目的だが、単純な足し合わせではなく下記のとおり取捨選択している。

元の 5 本は互いに重複が多い（`device_uuid` フィルタ追加が #356 と #369 の両方、`rel="noopener noreferrer"` が #347 と #348 の両方、`priority={false}` 削除が #348 と #359 の両方、`ImageModal.tsx` は 4 本すべてが触っている）。#348 は main と衝突しており、#347・#348 のマイグレーションはタイムスタンプが main の最新（`20260805120000`）より前だった。

## デプロイを壊すはずだった問題を1件修正した

**#369 をそのまま merge すると backend の Docker ビルドが落ちる。**

#369 は `cors.rb` と `storage.yml` を本番のみ `ENV.fetch` に変える（設定漏れを起動時に検出する狙いで、意図は正しい）。しかし `backend/Dockerfile` は

```
SECRET_KEY_BASE_DUMMY=1 CLOUDFRONT_BASE_URL=https://dummy ./bin/rails assets:precompile
```

を `RAILS_ENV=production` で実行しており、ここで initializer と `storage.yml` が両方とも評価される。ビルド環境に `FRONTEND_ORIGIN` も `AWS_*` も無いため `KeyError` で precompile が落ち、deploy ワークフローの build ジョブが失敗する。

`CLOUDFRONT_BASE_URL=https://dummy` が既に渡されているのは `cdn.rb` が同じ理由で `ENV.fetch` を使っているからで、前例がそのまま答えになっている。同じ扱いで `FRONTEND_ORIGIN` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_BUCKET` のダミーを Dockerfile に追加した。値の検証はコンテナ起動時の同じ `ENV.fetch` が担うので fail-fast の意図は損なわれない。

**検証:** ローカルで両方向を実走させて確認済み。

Dockerfile を修正前の状態に戻して `docker build` すると、想定どおり precompile で落ちる:

```
#13 1.014 KeyError: key not found: "FRONTEND_ORIGIN" (KeyError)
#13 ERROR: process "/bin/sh -c bundle exec bootsnap precompile app/ lib/ &&
    SECRET_KEY_BASE_DUMMY=1 CLOUDFRONT_BASE_URL=https://dummy ./bin/rails assets:precompile"
    did not complete successfully: exit code: 1
```

ダミー ENV を足した本 PR の Dockerfile では `docker build ./backend` が exit 0 で完走する。

## 取り込んだもの

### セキュリティ / 設定ミスの fail-fast
- `cors.rb` — 本番で `FRONTEND_ORIGIN` 未設定なら起動時に落とす（localhost:3002 へのフォールバックは本番で全 API を CORS エラーにする silent failure）
- `storage.yml` — `s3_prod` の AWS 認証情報を本番のみ `ENV.fetch`
- `backend/Dockerfile` — 上記に対応するビルド時ダミー ENV（前述）
- `next.config.ts` — `X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` / `Permissions-Policy` を全ルートに付与
- `layout.tsx` — JSON-LD のエスケープに `>` と `&` を追加
- `filter_parameter_logging.rb` — `device_uuid` をフィルタ対象に追加
- `e2e/` — `'password123'` のハードコードされたフォールバックを削除し、未設定なら throw

### エラーハンドリング
- `cdn_attached_file.rb` — rescue から `LoadError` を除去。`ScriptError` 系を捕まえると vips の読み込み失敗が silent fallback に埋もれる
- `api/images_controller.rb` — `taken_at` が nil のとき cursor を組み立てない（`nil.to_f` が `0.0` になり cursor が壊れる）
- `BucketListApp.tsx` — `useEffect` 内の Promise に `.catch` を追加

### 競合状態 / バリデーション
- `Camera` / `Lens` — `find_or_create_by!` → `create_or_find_by!`（EXIF 同時取り込みの TOCTOU）
- `Category` — `name` に uniqueness バリデーションとユニークインデックス

### 型安全性・単一ソース化
- `ProjectType.link` を `string | null` に修正し `ProjectCard` で null ガード
- `SiteHeader` — `HeaderVariant` を `HEADER_STYLE_PRESETS` から導出
- revalidate 秒数を各 API モジュールの定数に集約
- `ImageModal` — `Props` → `ImageModalProps`、既定値と同じ `priority={false}` を削除
- `CategoryCheckbox.test.tsx` — `import type` に修正

### UX / i18n
- `ImageModal` — `taken_at` が不正な日付文字列でも `Invalid Date` を表示しない
- `ImageModal` / `ImageGrid` — aria-label とローディング文言を日本語化
- `IntroSection` — `rel="noreferrer"` → `"noopener noreferrer"`
- Stimulus コントローラの JSDoc の `todo_*` を `bucket_list_*` に更新

## 元の PR から変えた点

- **`BucketListApp` の catch を握りつぶさない形に** — #359 は `.catch(() => {})` だった。エラーを消すのは方針に反するので `console.error` に残したうえで `fetchError` を立てるようにした。エラー UI は `items.length === 0` のときだけ出るので、SSR 済みデータがある状態で再取得に失敗しても表示は壊れない
- **`ProjectCard` の非 null アサーションを外した** — #348 は `href={project.link!}` だった。ローカル const に受ければ TS が絞り込めるので `!` は不要
- **マイグレーションのタイムスタンプを振り直した** — #348 の `20260805001500` は main の最新 `20260805120000` より前で、`schema.rb` の version が巻き戻る（これが #348 が CONFLICTING だった理由）。`20260814000000` に振り直し、`schema.rb` も整合させた

## 落としたもの

| 対象 | 理由 |
|------|------|
| `articles` / `publishments` テーブルの drop（#347） | 本番データの破棄を伴い、コード品質の範囲を超える。別途判断したいので本 PR には含めない |
| `extract_exif` の rescue 拡張 + `.rubocop.yml` の ClassLength 除外（#348） | `create_or_find_by!` に変えた時点で `RecordNotUnique` はそもそも到達しない（Rails が内部で rescue して find にフォールバックする）。lint 除外を足す理由もなくなった |
| eslint-disable コメントの削除（#369） | PR 内で revert 済み。`react-hooks/set-state-in-effect` は実在するルールだった |
| `admin/images` の before_action から `:index` を外す変更（#359） | PR 内で revert 済み。index の一括編集バーが `@cameras` / `@lenses` / `@categories` を使っている |

## デプロイ時の注意

`Category#name` のユニークインデックスを追加するため、本番に同名カテゴリが存在するとマイグレーションが失敗する。存在すればそれ自体がバグなので、fail-loud に落ちるのが期待動作。

## ローカル確認

- `docker build ./backend` — 成功（`assets:precompile` を含む）
- `yarn tsc --noEmit` / `yarn lint` / `yarn test` — すべて green（9 files / 40 tests）
- `bundle exec rubocop app/models app/controllers config db` — 51 files, no offenses

Closes #347
Closes #348
Closes #356
Closes #359
Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
