### PR TITLE
chore(db): 未使用の articles / publishments テーブルを削除する

### DIFF
--- a/backend/db/migrate/20260814010000_drop_dead_articles_and_publishments_tables.rb
+++ b/backend/db/migrate/20260814010000_drop_dead_articles_and_publishments_tables.rb
@@ -1,0 +1,20 @@
+# 2024-10 に作られたまま一度も使われなかったブログ機能のテーブルを削除する。
+# モデル・コントローラ・ルート・seed・spec のいずれからも参照がないことを確認済み。
+# drop_table にブロックを渡しているので down でスキーマは復元できる（データは戻らない）。
+class DropDeadArticlesAndPublishmentsTables < ActiveRecord::Migration[8.1]
+  def change
+    # 子テーブルを先に落とす（外部キー制約も一緒に消える）
+    drop_table :publishments do |t|
+      t.references :article, null: false, foreign_key: true
+      t.datetime :published_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamps
+    end
+
+    drop_table :articles do |t|
+      t.text :content, null: false
+      t.string :title, null: false
+      t.integer :status, default: 0, null: false
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_010000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,14 +40,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
-
-  create_table "articles", force: :cascade do |t|
-    t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.integer "status", default: 0, null: false
-    t.string "title", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "bucket_list_items", force: :cascade do |t|
@@ -128,14 +120,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
     t.string "tags", default: [], null: false, array: true
     t.string "title", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "publishments", force: :cascade do |t|
-    t.bigint "article_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "published_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "updated_at", null: false
-    t.index ["article_id"], name: "index_publishments_on_article_id"
   end
 
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
@@ -279,7 +263,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_000000) do
   add_foreign_key "image_categories", "images"
   add_foreign_key "images", "cameras"
   add_foreign_key "images", "lenses"
-  add_foreign_key "publishments", "articles"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade


### PR DESCRIPTION
## これは判断待ちの PR です（merge しないまま置いてあります）

#347 に含まれていた「未使用テーブルの削除」だけを切り出したもの。**本番データの破棄を伴う**ため、コード品質のまとめ（#372）には入れず単独にした。merge するかどうかは判断してほしい。

## 内容

`articles` と `publishments` は 2024-10 に作られたまま一度も使われていない。参照の有無を確認した結果、モデル・コントローラ・ルート・seed・spec のいずれからも参照されていない（`backend/app` `backend/config` `backend/lib` `backend/spec` `backend/db/seeds.rb` `frontend/src` を横断して grep 済み、ヒット 0）。

## #347 の版から直した点

元の #347 のマイグレーションはそのままだと壊れていた。

1. **`schema.rb` が更新されていなかった** — マイグレーションを足しただけだったので、`db:migrate` を実行するまで `schema.rb` にはテーブルが残る。spec は `schema.rb` を読むため、CI 上ではテーブルが消えていない状態で緑になっていた。テーブル定義・外部キー・version を反映した
2. **`down` の `articles` 定義が実スキーマと食い違っていた** — `title` / `body` になっていたが実際は `content` / `title` / `status`。`publishments.published_at` の default も落ちていた。`drop_table` にブロックを渡す可逆な形に書き直した
3. **タイムスタンプが古かった** — `20260803000000` は main の最新（`20260814000000`）より前。`20260814010000` に振り直した

## merge する前に確認したいこと

`down` でスキーマは戻せるが**データは戻らない**。テーブルが本当に空か（あるいは中身を捨ててよいか）を本番で確認してから merge するのが安全:

```sql
SELECT (SELECT count(*) FROM articles) AS articles,
       (SELECT count(*) FROM publishments) AS publishments;
```

不要と判断できるなら、この PR はそのまま merge して問題ない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)