### PR TITLE
fix(e2e): 資格情報を ENV に一本化して E2E を復旧する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,12 @@ jobs:
       POSTGRES_DB: portfolio_test
       NEXT_PUBLIC_API_BASE_URL: http://localhost:3000/api
       API_BASE_URL: http://localhost:3000/api
+      # seed（e2e:seed）と Playwright（auth.setup.ts）が同じ資格情報を読むための唯一の定義。
+      # 使い捨ての test DB 専用で、本番の認証情報とは無関係。
+      E2E_ADMIN_EMAIL: admin@example.com
+      E2E_ADMIN_PASSWORD: password123
+      E2E_GUEST_EMAIL: guest@example.com
+      E2E_GUEST_PASSWORD: password123
 
     services:
       postgres:

--- a/backend/lib/tasks/e2e.rake
+++ b/backend/lib/tasks/e2e.rake
@@ -14,11 +14,15 @@ namespace :e2e do
 end
 
 def seed_users
-  pw = 'password123'
-  User.create!(email: 'admin@example.com', password: pw,
-               password_confirmation: pw, role: :admin)
-  User.create!(email: 'guest@example.com', password: pw,
-               password_confirmation: pw, role: :guest)
+  # Playwright 側（e2e/tests/auth.setup.ts）と同じ ENV を読む。
+  # 片方だけ設定するとログインが通らないため、既定値もここに揃える。
+  admin_pw = ENV.fetch('E2E_ADMIN_PASSWORD', 'password123')
+  User.create!(email: ENV.fetch('E2E_ADMIN_EMAIL', 'admin@example.com'), password: admin_pw,
+               password_confirmation: admin_pw, role: :admin)
+
+  guest_pw = ENV.fetch('E2E_GUEST_PASSWORD', 'password123')
+  User.create!(email: ENV.fetch('E2E_GUEST_EMAIL', 'guest@example.com'), password: guest_pw,
+               password_confirmation: guest_pw, role: :guest)
 end
 
 def seed_camera_and_lens


### PR DESCRIPTION
## 背景

main の E2E Tests が #372 のマージ以降落ちている（[run 31801715476](https://github.com/huji333/portfolio/actions/runs/31801715476)）。

#372 で `auth.setup.ts` / `admin-access.spec.ts` のパスワードのハードコードフォールバックを削除し「未設定なら throw」にしたが、値を渡す側が存在しなかった。

- seed（`e2e:seed`）は `pw = 'password123'` を直書きのまま
- `e2e.yml` も ENV を渡していない

結果、setup が `Error: E2E_ADMIN_PASSWORD is required` で失敗し、admin プロジェクト 6 件が実行されないまま job が落ちていた。

さらに `admin-access.spec.ts` に同じ形の `E2E_GUEST_PASSWORD` の throw があり、admin を通した時点で 2 件目の失敗になる（ローカルで通して初めて表面化した）。

## 変更

- `.github/workflows/e2e.yml`: `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` / `E2E_GUEST_EMAIL` / `E2E_GUEST_PASSWORD` を job 直下の env に定義。seed ステップと playwright ステップが同じ値を読む唯一の定義点にする
- `backend/lib/tasks/e2e.rake`: 同じ ENV を読み、未設定時のみ既定値へフォールバック（ローカル実行の既存手順を壊さない）

throw 自体は残している（消すと #372 の fail-loud の意図が戻る）。使い捨ての test DB 専用の資格情報で、本番とは無関係。

## 検証

ローカルで **非既定値**（`local-e2e-pw` / `local-guest-pw`）を ENV 経由で渡して seed → playwright を実行し、ENV 経路が実際に効いていることを確認。

- setup + admin: 7 passed（guest のテストを含む）
- frontend: 4 passed
- `rubocop lib/tasks/e2e.rake`: no offenses

`e2e.yml` は `push: [main]` と `workflow_dispatch` のみのトリガのため PR では走らない。本ブランチに対して workflow_dispatch で実 CI を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)