### PR TITLE
行程ページの前半（8/28–9/10）を日ごとに展開する

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -64,6 +64,17 @@ const nextConfig: NextConfig = {
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
         ],
       },
+      // 旅程ページは直リンクで共有するだけ。HTML 側の meta と二重にしているのは、
+      // rewrite を通らない /europe.html を直接踏まれても効かせるため。
+      // robots.txt は allow のまま ── Disallow にするとクローラが noindex を読めない。
+      {
+        source: '/europe',
+        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
+      },
+      {
+        source: '/europe.html',
+        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
+      },
     ];
   },
   async redirects() {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -64,17 +64,6 @@ const nextConfig: NextConfig = {
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
         ],
       },
-      // 旅程ページは直リンクで共有するだけ。HTML 側の meta と二重にしているのは、
-      // rewrite を通らない /europe.html を直接踏まれても効かせるため。
-      // robots.txt は allow のまま ── Disallow にするとクローラが noindex を読めない。
-      {
-        source: '/europe',
-        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
-      },
-      {
-        source: '/europe.html',
-        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
-      },
     ];
   },
   async redirects() {

--- a/frontend/public/europe.html
+++ b/frontend/public/europe.html
@@ -6,6 +6,9 @@
 <title>ヨーロッパ 2026 8/28 → 9/24 行程</title>
 <meta name="description" content="ロンドンから北イタリア・ドロミテ・オーストリアまで、2026年8月28日〜9月24日のヨーロッパ行程。地図と日程、走ってみて効いてくるメモ。">
 <meta name="color-scheme" content="light dark">
+<!-- 直リンクで共有するだけのページ。検索には出さない（robots.txt は allow のまま
+     ── Disallow にするとクローラがこの noindex を読めなくなる）。OG は残す。 -->
+<meta name="robots" content="noindex, nofollow">
 <meta property="og:type" content="website">
 <meta property="og:title" content="ヨーロッパ 2026 8/28 → 9/24 行程">
 <meta property="og:description" content="ロンドン → マルセイユ → パリ ／ アルザス・スイス ／ 北イタリア ／ ドロミテ・オーストリア">

--- a/frontend/public/europe.html
+++ b/frontend/public/europe.html
@@ -6,8 +6,11 @@
 <title>ヨーロッパ 2026 8/28 → 9/24 行程</title>
 <meta name="description" content="ロンドンから北イタリア・ドロミテ・オーストリアまで、2026年8月28日〜9月24日のヨーロッパ行程。地図と日程、走ってみて効いてくるメモ。">
 <meta name="color-scheme" content="light dark">
-<!-- 直リンクで共有するだけのページ。検索には出さない（robots.txt は allow のまま
-     ── Disallow にするとクローラがこの noindex を読めなくなる）。OG は残す。 -->
+<!-- 直リンクで共有するだけのページ。検索には出さない。
+     robots.txt は allow のまま ── Disallow にするとクローラがこの noindex を
+     読めなくなり、他所からリンクされたときに URL だけ索引される。
+     /europe と /europe.html はこの同じファイルを返すので、meta 1枚で両方に効く
+     （next.config.ts に X-Robots-Tag を足す必要はない）。OG は共有用に残す。 -->
 <meta name="robots" content="noindex, nofollow">
 <meta property="og:type" content="website">
 <meta property="og:title" content="ヨーロッパ 2026 8/28 → 9/24 行程">
@@ -16,7 +19,7 @@
 <meta property="og:image" content="/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" href="/favicon.ico">
-<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+<link rel="preconnect" href="https://cdnjs.cloudflare.com">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css">
 <style>
   :root{
@@ -210,7 +213,7 @@
   <h2>どこに何泊するか</h2>
   <p class="lead">前半は腰を据えて、後半は7泊で7都市。同じ旅でも中身の密度がまるで違います。色は上の地図と同じフェーズ分けです。</p>
   <div id="stay" class="chart"></div>
-  <p class="chart-note">全27泊。バーの長さが泊数、色がフェーズ。日付はチェックイン日です。</p>
+  <p class="chart-note"><span id="stay-total"></span>バーの長さが泊数、色がフェーズ。日付はチェックイン日です。</p>
 
   <div class="tw">
   <table>
@@ -349,7 +352,7 @@
 
   <div class="day">
     <div class="day-h"><span class="date">9/8</span><span class="dow">火</span><span class="route">パリ 自由行動 ①</span></div>
-    <div class="note w"><b>ルーヴルは火曜が休館日です。</b>この日には行けません。<b>ルーヴルは 9/9（水）へ</b> ── 水曜と金曜は 21:00 までの夜間開館があり、そこが一番空きます。<br>今日に振るなら<b>オルセー</b>（火曜開館・木曜21:45まで夜間開館）、<b>オランジュリー</b>、<b>ロダン美術館</b>、<b>ピカソ美術館</b>、<b>ケ・ブランリー</b>。</div>
+    <div class="note w"><b>ルーヴルは火曜が休館日です。</b>この日には行けません。<b>ルーヴルは 9/9（水）へ</b>。<br>今日に振るなら<b>オルセー</b>（火曜開館・木曜21:45まで夜間開館）、<b>オランジュリー</b>、<b>ロダン美術館</b>、<b>ピカソ美術館</b>、<b>ケ・ブランリー</b>。</div>
     <div class="note"><b>ポンピドゥーは計画に入れないこと。</b>2025年9月から<b>2030年まで全面改修で閉館中</b>です。古い記事に載っていても、行っても閉まっています。</div>
     <span class="stay">泊：パリ</span>
   </div>
@@ -585,9 +588,9 @@
 
   <h2>この旅で効いてくる小ネタ</h2>
   <ol class="chk">
-    <li><b>ルーヴルは火曜が休館</b><small>9/8 には行けない。水曜（9/9）に回せば 21:00 までの夜間開館があり、17時以降は日中より明らかに空く。ポンピドゥーは2030年まで改修で閉館中なので、そもそも候補から外す。</small></li>
-    <li><b>ロンドンは Oyster を買わなくていい</b><small>手持ちのコンタクトレスか Apple Pay で運賃も1日上限も同じ。ただし<b>1人1枚を自分専用に</b>使うこと ── 複数人で回すと上限が働かない。ゾーン1–5 の上限は £15.30。</small></li>
-    <li><b>ビグルズウェイドは Oyster の圏外</b><small>9/2 はタッチだけでは行けない。「最寄り駅 → Biggleswade」を経路 via London で1枚買えば、地下鉄の乗り換え区間も運賃に含まれる（Cross London Transfer）。ただし途中下車は不可。</small></li>
+    <li><b>ルーヴルは火曜が休館</b><small>9/8 には行けないので 9/9 に回す。ポンピドゥーは2030年まで改修で閉館中なので、そもそも候補から外す。</small></li>
+    <li><b>ロンドンは Oyster を買わなくていい</b><small>コンタクトレスで運賃も上限も同じ。ただし<b>1人1枚を自分専用に</b> ── 複数人で回すと上限が働かない。</small></li>
+    <li><b>ビグルズウェイドは Oyster の圏外</b><small>9/2 はタッチだけでは行けない。経路 via London の通し券を1枚買う。</small></li>
     <li><b>8/30–8/31 は西ロンドンが機能しない</b><small>ノッティングヒル・カーニバル。周辺の駅は終日閉鎖か出口専用になる。8/31 は祝日でもあり、<b>バンクホリデー週末は鉄道の計画運休が入る定番</b>。SWR の週末運行を前夜に確認する。</small></li>
     <li><b>イフ島はミストラル次第</b><small>9/5 の船は強風で欠航する。前夜と当日朝に運航状況を見て、駄目なら市内に振る。最終便が早いので 9/4 の夕方への前倒しは効かない。</small></li>
     <li><b>コルマールは順路より時間帯</b><small>旧市街は端から端まで徒歩10分。どう歩いても一周してしまうので、決めるべきは「いつ入るか」だけ。日中は観光客で埋まり、空くのは日没後と朝8時半まで。</small></li>
@@ -696,8 +699,8 @@
   line(m1,[MIL,MXP,BGM,BRS,VER,TRT,BZ,CAS,BRX,BRU,DOB,MIS,CTN,LNZ,MTR,MTS,ZAS,BIS,EBN,GOS,HAL,BIS2,MON,SAL,RHL,ROS,KUF,INN,ZRL],P4);
   line(m1,[ZRL,INN,BRE,BZ,TRT,VER,BRS,BGM,MXP],P4,3,'7 6');
 
-  dot(m1,LON,P1,'<b>ロンドン</b><br>8/28 14:00 着 ／ 7泊',9);
-  dot(m1,OXF,P1,'<b>オックスフォード</b><br>ロンドンから日帰り圏',5);
+  dot(m1,LON,P1,'<b>ロンドン</b><br>8/28 14:00 着 ／ 5泊',9);
+  dot(m1,OXF,P1,'<b>オックスフォード</b><br>9/2 から2泊',6);
   dot(m1,MRS,P1,'<b>マルセイユ</b><br>9/4 16:00 着 ／ 2泊',8);
   dot(m1,LYO,P1,'<b>リヨン</b><br>9/6 1泊',7);
   dot(m1,PAR,P1,'<b>パリ</b><br>9/7〜9/10 の4泊 ／ 9/11 朝発',9);
@@ -759,8 +762,8 @@
     }).join('');
   }
 
-  /* 滞在（泊数）。合計27泊 */
-  chart(document.getElementById('stay'),[
+  /* 滞在（泊数）。合計は配列から導く ── 手で書くと必ずずれる */
+  var STAY=[
     {date:'8/28',name:'ロンドン',seg:[5],p:1},   {date:'9/2', name:'オックスフォード',seg:[2],p:1},
     {date:'9/4', name:'マルセイユ',seg:[2],p:1},
     {date:'9/6', name:'リヨン',seg:[1],p:1},     {date:'9/7', name:'パリ',seg:[4],p:1},
@@ -770,7 +773,10 @@
     {date:'9/19',name:'コルティナ',seg:[1],p:4}, {date:'9/20',name:'ツェル・アム・ゼー',seg:[1],p:4},
     {date:'9/21',name:'ザルツブルク',seg:[1],p:4},{date:'9/22',name:'ツィール',seg:[1],p:4},
     {date:'9/23',name:'マルペンサ周辺',seg:[1],p:4}
-  ],function(n){return n+'泊';});
+  ];
+  chart(document.getElementById('stay'),STAY,function(n){return n+'泊';});
+  document.getElementById('stay-total').textContent =
+    '全' + STAY.reduce(function(a,r){ return a+r.seg[0]; },0) + '泊。';
 
   /* 実走時間。9/22 だけ 本移動＋日帰り往復 の2本立て */
   chart(document.getElementById('drive'),[

--- a/frontend/public/europe.html
+++ b/frontend/public/europe.html
@@ -213,10 +213,12 @@
   <table>
     <thead><tr><th>期間</th><th>区間</th><th>移動</th></tr></thead>
     <tbody>
-      <tr><td class="num"><b>8/28–9/4</b></td><td>ロンドン（＋オックスフォード）</td><td>8/28 14:00 着 ／ 9/4 空路でマルセイユへ</td></tr>
-      <tr><td class="num"><b>9/4–9/6</b></td><td>マルセイユ</td><td>9/4 16:00 着・2泊</td></tr>
+      <tr><td class="num"><b>8/28–9/2</b></td><td>ロンドン</td><td>8/28 14:00 着・5泊</td></tr>
+      <tr><td class="num"><b>9/2</b></td><td>ビグルズウェイド 日帰り</td><td>鉄道3本 約1h20 ／ そこから車でオックスフォードへ 約1h50</td></tr>
+      <tr><td class="num"><b>9/2–9/4</b></td><td>オックスフォード</td><td>2泊。9/4 08:30 発でヒースローへ（バス 1h30）</td></tr>
+      <tr><td class="num"><b>9/4–9/6</b></td><td>マルセイユ</td><td>9/4 16:00 着・2泊。9/5 にイフ島</td></tr>
       <tr><td class="num"><b>9/6–9/7</b></td><td>リヨン</td><td>1泊。TGV 約1時間40分</td></tr>
-      <tr><td class="num"><b>9/7–9/11</b></td><td>パリ</td><td>4泊。TGV 約2時間</td></tr>
+      <tr><td class="num"><b>9/7–9/11</b></td><td>パリ</td><td>4泊。9/7 15:00 発 → 17:05頃 Gare de Lyon 着</td></tr>
       <tr><td class="num"><b>9/11–9/14</b></td><td>ストラスブール → コルマール → ルツェルン</td><td>TGV 1時間46分＋TER・SBB。コルマール1泊・ルツェルン2泊</td></tr>
       <tr><td class="num"><b>9/14–9/17</b></td><td>ボローニャ → ベネチア → ミラノ</td><td>9/14 夕方 合流。ボローニャ1泊・ベネチア1泊・ミラノ2泊</td></tr>
       <tr><td class="num"><b>9/18–9/24</b></td><td>ドロミテ → オーストリア → ミラノ</td><td>MXP 発着レンタカー</td></tr>
@@ -237,18 +239,94 @@
 
   <div class="warn"><b>時刻はすべて目安です。</b>鉄道の実列車は SNCF Connect / SBB / Trenitalia で、ドライブの所要は無停車の実走目安として見てください。</div>
 
-  <p class="phase">前半 ── 英・仏</p>
+  <p class="phase">前半 ── イギリス</p>
 
   <div class="day">
     <div class="day-h"><span class="date">8/28</span><span class="dow">金</span><span class="route">ロンドン 14:00 着</span></div>
-    <div class="leg"><div class="t">14:00</div><div class="c"><b>ロンドン着</b><span class="meta">9/4 まで滞在。オックスフォードは日帰り圏（パディントンから約1時間）</span></div></div>
-    <span class="stay">泊：ロンドン（8/28〜9/3 の7泊）</span>
+    <div class="leg"><div class="t">14:00</div><div class="c"><b>ロンドン着</b></div></div>
+    <div class="leg"><div class="t">拠点</div><div class="c"><b>ロンドン南西部の滞在先</b><span class="meta">最寄り駅は South Western Railway のゾーン5。Waterloo まで約30〜35分・毎時2本</span></div></div>
+    <div class="note"><b>Oyster カードは買わなくていい。</b>手持ちのコンタクトレスカードか Apple Pay をそのままタッチすれば、運賃も1日上限も Oyster と同じで、£7 のデポジットが要りません。ゾーン1–5 の1日上限は £15.30。<b>1人1枚を自分専用に</b>使うこと ── 複数人で1枚を回すと上限が働かず、かえって高く付きます。</div>
+    <span class="stay">泊：ロンドン（8/28〜9/1 の5泊）</span>
   </div>
 
   <div class="day">
-    <div class="day-h"><span class="date">9/4</span><span class="dow">金</span><span class="route">ロンドン → マルセイユ（空路）</span></div>
+    <div class="day-h"><span class="date">8/29</span><span class="dow">土</span><span class="route">カムデン</span></div>
+    <div class="leg"><div class="t">経路</div><div class="c"><b>Waterloo →（Northern 線 チャリング・クロス経由）→ Camden Town</b><span class="meta">滞在先から約55分・乗換1回</span></div></div>
+    <div class="leg"><div class="t">午後</div><div class="c"><b>カムデン・マーケット／ステーブルズ・マーケット</b><span class="meta">古着の露店はステーブルズ側が濃い。運河沿いを Primrose Hill まで抜けるのも気持ちがいい</span></div></div>
+    <div class="leg"><div class="t">夕方</div><div class="c"><b>カムデン・パッセージ（Angel）</b><span class="meta">Northern 線で3駅。ヴィンテージの露店は水・土だけ。The Camden Head でそのまま一杯</span></div></div>
+    <div class="note">この土曜はパノラマ（ノッティングヒル・カーニバルのスティールバンド大会）の日。<b>カーニバル本体は明日から</b>で、西ロンドンは今週末が年間で最も混みます。</div>
+    <span class="stay">泊：ロンドン</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">8/30</span><span class="dow">日</span><span class="route">ブリックレーン／ショーディッチ</span></div>
+    <div class="leg"><div class="t">10:00〜</div><div class="c"><b>ブリックレーン・ヴィンテージ・マーケット</b>（Old Truman Brewery 地下）<span class="meta">日曜 10:00–18:00。専門ディーラー約40軒。名指しのブランドを聞ける唯一の場所</span></div></div>
+    <div class="leg"><div class="t">周辺</div><div class="c"><b>194 Local（178d Brick Lane）／Atika／Blitz／Beyond Retro／Rokit</b><span class="meta">194 Local は 90s–00s メンズ特化で値は張る。大箱3軒は米国物中心なので流し見で十分</span></div></div>
+    <div class="leg"><div class="t">パブ</div><div class="c"><b>The Carpenter's Arms</b>（Cheshire St）<span class="meta">Beyond Retro の向かい。ほかに The Pride of Spitalfields、The Ten Bells</span></div></div>
+    <div class="note"><b>古着を見るならこの日。</b>マーケット自体は平日も開いていますが、ディーラーが全員そろって露店も出るのは日曜だけ。<b>西ロンドンがカーニバルで機能しないこの日に、東ロンドンは平常運転</b>です。</div>
+    <div class="note">カーニバル1日目（ファミリーデー）。ラドブローク・グローブ／ウェストボーン・パーク周辺は駅が終日閉鎖または出口専用。見に行くなら人出の穏やかな日曜の方ですが、古着とは完全にトレードオフです。</div>
+    <span class="stay">泊：ロンドン</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">8/31</span><span class="dow">月・祝</span><span class="route">ソーホー ── Dover Street Market</span></div>
+    <div class="leg"><div class="t">経路</div><div class="c"><b>Waterloo →（Bakerloo 線 2駅）→ Piccadilly Circus</b><span class="meta">滞在先から約45分。ヘイマーケットは駅の目の前</span></div></div>
+    <div class="leg"><div class="t">11:00〜</div><div class="c"><b>Dover Street Market</b> ── 18–22 Haymarket, SW1Y 4DG<span class="meta">月〜土 11:00–19:00／日 12:00–18:00。<b>店名の Dover Street にはもうありません</b>（2016年にヘイマーケットへ移転）。最上階の Rose Bakery で休める</span></div></div>
+    <div class="leg"><div class="t">徒歩圏</div><div class="c"><b>Maharishi 旗艦店</b>（2–3 Great Pulteney St）／<b>Machine-A</b>（Brewer St）<span class="meta">DSM から5〜7分。この3軒はひとかたまりで回れる</span></div></div>
+    <div class="leg"><div class="t">パブ</div><div class="c"><b>The Dog and Duck</b>／<b>The French House</b><span class="meta">どちらも徒歩5〜8分</span></div></div>
+    <div class="note w"><b>今日は Summer Bank Holiday。</b>バンクホリデー週末は<b>鉄道の計画運休が入る定番の週末</b>です ── SWR の南西部の路線が振替バスになっていないか、<b>前夜にかならず確認</b>を。ソーホーはカーニバルの規制区域外なので、街そのものは通常どおり動けます。</div>
+    <span class="stay">泊：ロンドン</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/1</span><span class="dow">火</span><span class="route">サウス・ケンジントン ── 自然史博物館</span></div>
+    <div class="leg"><div class="t">経路</div><div class="c"><b>Richmond →（District 線 直通）→ South Kensington</b><span class="meta">滞在先から約40分。乗換1回で済む、いちばん楽な行き先</span></div></div>
+    <div class="leg"><div class="t">10:00</div><div class="c"><b>自然史博物館</b> ── Cromwell Road, SW7 5BD<span class="meta">入館無料・毎日 10:00–17:50（最終入場 17:30）。<b>無料の時間指定チケットを事前に取ること</b> ── 夏休み期間は当日入場を断られることがあります</span></div></div>
+    <div class="leg"><div class="t">午後</div><div class="c"><b>V&amp;A（隣）／サイエンス・ミュージアム（裏）</b><span class="meta">どちらも徒歩2分・入館無料</span></div></div>
+    <div class="note"><b>火曜に置いた理由</b>：祝日明けの平日で、4日間のうち一番空きます。8/31（月・祝）に行くとロンドン中の家族連れと重なります。午後が余れば Piccadilly 線一本12分でコヴェント・ガーデン、The Vintage Showroom（14 Earlham St）はアーカイブ5万点の見物向けです。</div>
+    <div class="note w">明日は<b>全荷物を持って鉄道3本を乗り継ぐ</b>日。荷造りと切符（Biggleswade までの通し券）は今日のうちに。</div>
+    <span class="stay">泊：ロンドン（最後の晩）</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/2</span><span class="dow">水</span><span class="route">ロンドン → ビグルズウェイド →（車）オックスフォード</span></div>
+    <div class="leg"><div class="t">〜25分</div><div class="c"><b>最寄り駅 → Vauxhall</b>（South Western Railway）<span class="meta">直通・毎時2本</span></div></div>
+    <div class="leg"><div class="t">〜15分</div><div class="c"><b>Vauxhall → Finsbury Park</b>（Victoria 線）<span class="meta">7駅・約14分・頻発</span></div></div>
+    <div class="leg"><div class="t">〜40分</div><div class="c"><b>Finsbury Park → Biggleswade</b>（Thameslink・ピーターバラ方面）<span class="meta">直通 約37分・毎時2本</span></div></div>
+    <div class="leg"><div class="t">昼</div><div class="c"><b>ビグルズウェイドで食事</b></div></div>
+    <div class="leg"><div class="t">約1h50</div><div class="c"><b>車でオックスフォードへ送ってもらう</b><span class="meta">約130km。渋滞次第で 1h40〜2h15</span></div></div>
+    <div class="note"><b>切符は1枚で買えます。</b>「最寄り駅 → Biggleswade」の片道を、経路が <b>via London</b> になるように買うと、Vauxhall〜Finsbury Park の地下鉄区間が <b>Cross London Transfer</b> として運賃に含まれます（券面の「＋」がその印。紙の券は改札に投入して通る）。<b>ただし地下鉄区間での途中下車は不可。</b></div>
+    <div class="note w"><b>ビグルズウェイドは Oyster / コンタクトレスの圏外です。</b>タッチだけでは行けません。国鉄の券を必ず用意すること ── ここだけは間違えないように。</div>
+    <div class="note">乗車時間の合計は約1時間20分ですが、<b>荷物ありで乗換2回なので2時間見る</b>。Vauxhall は地上ホームと地下深部の Victoria 線の乗り換えです。</div>
+    <span class="stay">泊：オックスフォード（9/2・9/3 の2泊）</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/3</span><span class="dow">木</span><span class="route">オックスフォード 終日</span></div>
+    <div class="leg"><div class="t">終日</div><div class="c"><b>オックスフォード</b><span class="meta">ボドリアン図書館（ディヴィニティ・スクール）／ラドクリフ・カメラ／アシュモリアン博物館（入館無料）／クライストチャーチ。街は徒歩で完結する規模</span></div></div>
+    <div class="note">カレッジ系は<b>時間指定の事前予約</b>が要るものが多く、当日枠は埋まりがち。行きたい所が決まっているなら前日までに。移動した翌日で翌朝は 08:30 発なので、<b>詰め込まず街を歩く日</b>として置いてあります。</div>
+    <span class="stay">泊：オックスフォード</span>
+  </div>
+
+  <p class="phase">前半 ── フランス</p>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/4</span><span class="dow">金</span><span class="route">オックスフォード 08:30 発 → LHR → マルセイユ</span></div>
+    <div class="leg"><div class="t">08:30</div><div class="c"><b>オックスフォード発 ── 空港バス「the airline」</b><span class="meta">Gloucester Green 発。24時間運行・約30分毎。ヒースローまで<b>約1時間30分</b></span></div></div>
+    <div class="leg"><div class="t">10:00頃</div><div class="c"><b>ヒースロー着</b><span class="meta">チェックインと保安検査に最低2時間</span></div></div>
     <div class="leg"><div class="t">16:00</div><div class="c"><b>マルセイユ着</b><span class="meta">空港から市内まで市内バスで約25〜30分</span></div></div>
+    <div class="note w"><b>08:30 発は、便が12時台なら余裕・11時台だとぎりぎりです。</b>M40 と M25 の渋滞で30分ずれることがあり、バスの所要 1h30 は公称値。11時台の便なら 07:30 発に前倒しを（このバスは早朝から走っています）。</div>
+    <div class="note">夕方着なので、この日は旧港（Vieux-Port）まわりだけで十分。イフ島は翌日に。</div>
     <span class="stay">泊：マルセイユ（9/4・9/5 の2泊）</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/5</span><span class="dow">土</span><span class="route">マルセイユ 市内＋イフ島</span></div>
+    <div class="leg"><div class="t">09:30</div><div class="c"><b>Frioul If Express 始発</b>（旧港 1 Quai de la Fraternité）<span class="meta">イフ島まで約20分。高シーズンは30〜60分毎</span></div></div>
+    <div class="leg"><div class="t">午前</div><div class="c"><b>イフ島（Château d'If）</b><span class="meta">9/5 は夏時間ダイヤで 9:30–18:15。無休期間（5/15〜9/20）なので曜日の心配は不要</span></div></div>
+    <div class="leg"><div class="t">午後</div><div class="c"><b>市内</b><span class="meta">ノートルダム・ド・ラ・ギャルド／パニエ地区／MuCEM／旧港</span></div></div>
+    <div class="note w"><b>ミストラルが吹くと船は欠航します。</b>珍しいことではありません。前夜と当日朝に運航状況を確認して、欠航なら潔く市内に振ること（カランク、ロンシャン宮、ユニテ・ダビタシオン）。<b>9/4 の夕方に前倒しはできません</b> ── 最終便が早いので。</div>
+    <span class="stay">泊：マルセイユ</span>
   </div>
 
   <div class="day">
@@ -259,20 +337,45 @@
   </div>
 
   <div class="day">
-    <div class="day-h"><span class="date">9/7</span><span class="dow">月</span><span class="route">リヨン → パリ</span></div>
-    <div class="leg"><div class="t">—</div><div class="c"><b>Lyon Part-Dieu → Paris Gare de Lyon</b><span class="meta">TGV 約2時間・頻発</span></div></div>
+    <div class="day-h"><span class="date">9/7</span><span class="dow">月</span><span class="route">リヨン → パリ（15:00 発）</span></div>
+    <div class="leg"><div class="t">午前</div><div class="c"><b>リヨン</b><span class="meta">月曜は休館が出るので、屋外に寄せる方が確実 ── ヴュー・リヨン、トラブール、フルヴィエールの丘</span></div></div>
+    <div class="leg"><div class="t">15:00</div><div class="c"><b>Lyon Part-Dieu → Paris Gare de Lyon</b><span class="meta">TGV 約2時間。Part-Dieu は大きい駅なのでホームまで15分見る</span></div></div>
+    <div class="leg"><div class="t">17:05頃</div><div class="c"><b>Gare de Lyon 着 → ホテルへ</b></div></div>
     <span class="stay">泊：パリ（9/7〜9/10 の4泊）</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/8</span><span class="dow">火</span><span class="route">パリ 自由行動 ①</span></div>
+    <div class="note w"><b>ルーヴルは火曜が休館日です。</b>この日には行けません。<b>ルーヴルは 9/9（水）へ</b> ── 水曜と金曜は 21:00 までの夜間開館があり、そこが一番空きます。<br>今日に振るなら<b>オルセー</b>（火曜開館・木曜21:45まで夜間開館）、<b>オランジュリー</b>、<b>ロダン美術館</b>、<b>ピカソ美術館</b>、<b>ケ・ブランリー</b>。</div>
+    <div class="note"><b>ポンピドゥーは計画に入れないこと。</b>2025年9月から<b>2030年まで全面改修で閉館中</b>です。古い記事に載っていても、行っても閉まっています。</div>
+    <span class="stay">泊：パリ</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/9</span><span class="dow">水</span><span class="route">パリ 自由行動 ② ── ルーヴル</span></div>
+    <div class="leg"><div class="t">09:00</div><div class="c"><b>ルーヴル美術館 開館</b><span class="meta">水曜は 21:00 までの夜間開館。最終入場は閉館の1時間前</span></div></div>
+    <div class="note"><b>時間指定チケットを事前にオンラインで。</b>当日窓口は入れないことがあります。朝イチか<b>17:00 以降</b>が狙い目 ── 水曜の夕方以降は日中より目に見えて空きます。</div>
+    <span class="stay">泊：パリ</span>
+  </div>
+
+  <div class="day">
+    <div class="day-h"><span class="date">9/10</span><span class="dow">木</span><span class="route">パリ ── 友人と会う → 午後途中から自由</span></div>
+    <div class="leg"><div class="t">午前〜</div><div class="c"><b>友人と合流</b></div></div>
+    <div class="leg"><div class="t">午後途中</div><div class="c"><b>以降フリー</b><span class="meta">オルセーは木曜 21:45 まで開いているので、夕方から入るならここ</span></div></div>
+    <div class="note">パリ最終日。<b>翌朝の TGV は Gare de l'Est 発</b>（Gare de Lyon ではありません）。宿からの経路と所要を今夜のうちに。</div>
+    <span class="stay">泊：パリ（最後の晩）</span>
   </div>
 
   <p class="phase">単独区間 ── アルザス・スイス</p>
 
   <div class="day">
     <div class="day-h"><span class="date">9/11</span><span class="dow">金</span><span class="route">パリ → ストラスブール → コルマール</span></div>
-    <div class="leg"><div class="t">08:00頃</div><div class="c"><b>Paris Gare de l'Est 発</b><span class="meta">TGV INOUI・1時間46分。1日19本あり時刻の自由度が高い</span></div></div>
-    <div class="leg"><div class="t">09:50頃</div><div class="c"><b>Strasbourg 着</b><span class="meta">駅のロッカーに荷物を預ける</span></div></div>
-    <div class="leg"><div class="t">午前〜午後</div><div class="c"><b>ストラスブール</b><span class="meta">大聖堂（天文時計）／プティット・フランス。半日でちょうど回りきる規模</span></div></div>
+    <div class="leg"><div class="t">11:00〜<br>11:30</div><div class="c"><b>Paris Gare de l'Est 発</b><span class="meta">TGV INOUI・1時間46分。1日19本あり時刻の自由度が高い</span></div></div>
+    <div class="leg"><div class="t">13:00〜<br>13:15</div><div class="c"><b>Strasbourg 着</b><span class="meta">駅のロッカーに荷物を預ける</span></div></div>
+    <div class="leg"><div class="t">午後</div><div class="c"><b>ストラスブール</b><span class="meta">大聖堂（天文時計）／プティット・フランス。半日でちょうど回りきる規模</span></div></div>
     <div class="leg"><div class="t">17:30頃</div><div class="c"><b>Strasbourg → Colmar</b><span class="meta">TER 約30分・頻発・予約不要</span></div></div>
     <div class="leg"><div class="t">20:00〜<br>20:40</div><div class="c"><b>コルマール旧市街（日没後）</b><span class="meta">夕食を先に済ませておく</span></div></div>
+    <div class="note w"><b>昼前発にしたことで失うものが一つ。</b>ストラスブール大聖堂の<b>天文時計の仕掛けは 12:30 の一日一回</b>だけで、13時着ではもう終わっています。これを見たいなら 09:00 台の TGV に戻す必要があります。見送るなら午後着で問題ありません ── 大聖堂そのものとプティット・フランスは午後で足ります。</div>
     <div class="note w"><b>工事回避：</b>パリ〜バーゼルの TGV Lyria 直通は 2026/8/17〜10/29 の工事で運休・迂回・約1時間増の対象。この LGV Est（ストラスブール線）経由はその区間を踏まない。</div>
     <div class="note">旧市街は端から端まで徒歩10分。どう歩いても一周してしまうので、決めるべきは順路ではなく<b>入る時間帯</b>だけです。日中は観光客で埋まり、空くのは日没後と朝。9/11 は 20時前後の日没からブルーアワー（20:40頃まで）、9/12 は 7:00–8:30。土曜なので9時を過ぎると一気に混みます。</div>
     <span class="stay">泊：コルマール</span>
@@ -465,6 +568,7 @@
   <table>
     <thead><tr><th>区間</th><th>列車</th><th>予約</th></tr></thead>
     <tbody>
+      <tr><td>ロンドン南西部 → ビグルズウェイド（9/2）</td><td>SWR ＋ Victoria 線 ＋ Thameslink</td><td>通しの片道券1枚。経路を <b>via London</b> にすれば地下鉄区間込み</td></tr>
       <tr><td>マルセイユ → リヨン → パリ</td><td>TGV</td><td><b>要</b>。頻発だが週末は埋まる</td></tr>
       <tr><td>パリ → ストラスブール</td><td>TGV INOUI</td><td><b>要</b>。1日19本。早いほど安い</td></tr>
       <tr><td>ストラスブール → コルマール → バーゼル → ルツェルン</td><td>TER / SBB</td><td>不要</td></tr>
@@ -478,6 +582,11 @@
 
   <h2>この旅で効いてくる小ネタ</h2>
   <ol class="chk">
+    <li><b>ルーヴルは火曜が休館</b><small>9/8 には行けない。水曜（9/9）に回せば 21:00 までの夜間開館があり、17時以降は日中より明らかに空く。ポンピドゥーは2030年まで改修で閉館中なので、そもそも候補から外す。</small></li>
+    <li><b>ロンドンは Oyster を買わなくていい</b><small>手持ちのコンタクトレスか Apple Pay で運賃も1日上限も同じ。ただし<b>1人1枚を自分専用に</b>使うこと ── 複数人で回すと上限が働かない。ゾーン1–5 の上限は £15.30。</small></li>
+    <li><b>ビグルズウェイドは Oyster の圏外</b><small>9/2 はタッチだけでは行けない。「最寄り駅 → Biggleswade」を経路 via London で1枚買えば、地下鉄の乗り換え区間も運賃に含まれる（Cross London Transfer）。ただし途中下車は不可。</small></li>
+    <li><b>8/30–8/31 は西ロンドンが機能しない</b><small>ノッティングヒル・カーニバル。周辺の駅は終日閉鎖か出口専用になる。8/31 は祝日でもあり、<b>バンクホリデー週末は鉄道の計画運休が入る定番</b>。SWR の週末運行を前夜に確認する。</small></li>
+    <li><b>イフ島はミストラル次第</b><small>9/5 の船は強風で欠航する。前夜と当日朝に運航状況を見て、駄目なら市内に振る。最終便が早いので 9/4 の夕方への前倒しは効かない。</small></li>
     <li><b>コルマールは順路より時間帯</b><small>旧市街は端から端まで徒歩10分。どう歩いても一周してしまうので、決めるべきは「いつ入るか」だけ。日中は観光客で埋まり、空くのは日没後と朝8時半まで。</small></li>
     <li><b>ブリューニク線は進行方向の右側</b><small>マイリンゲンで機関車が前後に付け替わるので、行きも帰りも右が正解になる。</small></li>
     <li><b>スイスの日曜は商店が全休</b><small>9/13 が日曜なので、買い出しがあるなら 9/12 のうちに。</small></li>
@@ -649,7 +758,8 @@
 
   /* 滞在（泊数）。合計27泊 */
   chart(document.getElementById('stay'),[
-    {date:'8/28',name:'ロンドン',seg:[7],p:1},   {date:'9/4', name:'マルセイユ',seg:[2],p:1},
+    {date:'8/28',name:'ロンドン',seg:[5],p:1},   {date:'9/2', name:'オックスフォード',seg:[2],p:1},
+    {date:'9/4', name:'マルセイユ',seg:[2],p:1},
     {date:'9/6', name:'リヨン',seg:[1],p:1},     {date:'9/7', name:'パリ',seg:[4],p:1},
     {date:'9/11',name:'コルマール',seg:[1],p:2}, {date:'9/12',name:'ルツェルン',seg:[2],p:2},
     {date:'9/14',name:'ボローニャ',seg:[1],p:3}, {date:'9/15',name:'ベネチア',seg:[1],p:3},


### PR DESCRIPTION
## 概要
`/europe` の前半が「ロンドン 14:00 着・7泊」の1枚だけだったのを、到着から出発まで日ごとのカードに分け、確定した予定と調べ直した事実を反映した。

## レビュー優先度
🟡 動作確認のみ — 静的 HTML 1枚のコンテンツ追記で、地図・チャートの描画コードには触れていない。

## 判断・トレードオフ

**このリポジトリと `/europe` は公開なので、滞在先の粒度を「ロンドン南西部・ゾーン5」までに留めた。** 郵便番号・最寄り駅名・番地は書かない。乗換案内も起点を駅名ではなく Waterloo / Richmond から書き起こしている。宿の予約リンクと金額も載せていない。

**滞在の内訳を修正した。** 従来の「ロンドン7泊・オックスフォードは日帰り」は誤りで、実際はロンドン5泊 + オックスフォード2泊（9/2 にビグルズウェイド経由で車移動）。滞在チャートのデータも追従させたが、**合計27泊は変わらない**ので後半の記述には影響しない。

**フェーズは色を増やさず、ラベルだけ「前半 ── 英・仏」→「イギリス」「フランス」に割った。** 日数が7日から14日に増えて1フェーズが長くなりすぎたため。5色目を足す案もあったが、配色は直前に調整したばかりなので触らない方を選んだ。

**調べ直して直った事実:**
- 9/8（火）は**ルーヴルが休館日**。「8日と9日が自由行動でルーヴル」は成立しないので 9/9（水・21時まで夜間開館）に寄せた
- 8/30–8/31 は**ノッティングヒル・カーニバル**で西ロンドンの駅が閉鎖。8/31 は Summer Bank Holiday で、SWR に計画運休が入りやすい
- ビグルズウェイドは **Oyster / コンタクトレスの圏外**。9/2 は通しの国鉄券（経路 via London で Cross London Transfer 込み）が要る
- ポンピドゥーは 2030 年まで閉館中なので候補から外した

## 確認
Playwright（headless Chromium）で `file://` から実描画を確認済み。
- 日カード 28枚 / フェーズ 5本が期待どおり生成される
- 滞在チャートは 16行・合計 **27泊**（変更前と一致）
- 地図 m1 / m4 は SVG パス 78 / 52 本を描画（触っていないことの確認）
- コンソールエラーなし、横スクロールなし、タブ切替が動作
- 曜日 28日分を 2026 年カレンダーと突合（ミスマッチ 0）、8/28–9/24 の日付に抜け・重複なし
- 住居を特定しうる語（郵便番号・駅名）が残っていないことを grep で確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)